### PR TITLE
Explicitly lowercase hostname to prevent mixed-case duplicates.

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -188,6 +188,7 @@ def normalizeRule(rule):
 	result = re.search(r'^[ \t]*(\d+\.\d+\.\d+\.\d+)\s+([\w\.-]+)(.*)',rule)
 	if result:
 		target, hostname, suffix = result.groups()
+		hostname = hostname.lower() # explicitly lowercase hostname
 		return hostname, "%s %s %s\n" % (TARGET_HOST, hostname, suffix)
 	print '==>%s<==' % rule
 	return None, None

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -189,7 +189,11 @@ def normalizeRule(rule):
 	if result:
 		target, hostname, suffix = result.groups()
 		hostname = hostname.lower() # explicitly lowercase hostname
-		return hostname, "%s %s %s\n" % (TARGET_HOST, hostname, suffix)
+		if suffix is not '':
+			# add suffix as comment only, not as a separate host
+			return hostname, "%s %s #%s\n" % (TARGET_HOST, hostname, suffix)
+		else:
+			return hostname, "%s %s\n" % (TARGET_HOST, hostname)
 	print '==>%s<==' % rule
 	return None, None
 


### PR DESCRIPTION
While trying to use the list as a base for bind9 config files (and zone names are case-sensitive in it), i've found few duplicates slipped in, e.g.:

0.0.0.0 adsatt.abcnews.starwave.com 
0.0.0.0 Adsatt.ABCNews.starwave.com

The proposed simple patch fixes that.