### PR TITLE
hotfix for duplicates and artefacts

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -90,6 +90,7 @@ exclusionRegexs = []
 numberOfRules = 0
 
 def main():
+	removeOldHostsFile()
 	promptForUpdate()
 	promptForExclusions()
 	mergeFile = createInitialFile()
@@ -313,6 +314,12 @@ def moveHostsFileIntoPlace(finalFile):
 	elif (os.name == 'nt'):
 		print ('Automatically moving the hosts file in place is not yet supported.')
 		print ('Please move the generated file to %SystemRoot%\system32\drivers\etc\hosts')
+		
+def removeOldHostsFile():       		# hotfix since merging with an already existing hosts file leads to artefacts and duplicates
+	oldFilePath=os.path.join(BASEDIR_PATH,'hosts')
+	open(oldFilePath, 'a').close()		# create if already removed, so remove wont raise an error
+	os.remove(oldFilePath);
+	open(oldFilePath, 'a').close()		# create new empty hostsfile
 
 # End File Logic
 

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -90,10 +90,10 @@ exclusionRegexs = []
 numberOfRules = 0
 
 def main():
-	removeOldHostsFile()
 	promptForUpdate()
 	promptForExclusions()
 	mergeFile = createInitialFile()
+	removeOldHostsFile()
 	finalFile = removeDupsAndExcl(mergeFile)
 	finalizeFile(finalFile)
 	updateReadme(numberOfRules)


### PR DESCRIPTION
Issue #41

Merging with an already existing hosts file leads to duplicates and artefacts.

Now: Generate hosts file from the scratch
This is just a little fix that will prevent the occurence of that behavior.
This should not be considered a permanent solution.