### PR TITLE
Recommend to remove Google Analytics record

### DIFF
--- a/hosts
+++ b/hosts
@@ -27990,7 +27990,6 @@
 0.0.0.0 amazon-adsystem.com
 0.0.0.0 amung.us
 0.0.0.0 anahtars.com
-0.0.0.0 analytics.google.com
 0.0.0.0 analytics.yahoo.com
 0.0.0.0 api.intensifier.de
 0.0.0.0 apture.com


### PR DESCRIPTION
I would recommend to remove analytics.google.com from the list because it makes impossible to use google analytics. I didn't change your python script or something else, but just removed the record from the host file.