### PR TITLE
Revert HTTPS for MDL due connection issue

### DIFF
--- a/data/malwaredomainlist.com/update.info
+++ b/data/malwaredomainlist.com/update.info
@@ -1,1 +1,1 @@
-https://www.malwaredomainlist.com/hostslist/hosts.txt
+http://www.malwaredomainlist.com/hostslist/hosts.txt


### PR DESCRIPTION
@StevenBlack

host file via web browser from URL https://www.malwaredomainlist.com/hostslist/hosts.txt is available BUT cannot be download due SSL connection ISSUE:


`[tomasz@arch ~]$ export LANG=C`
`[tomasz@arch ~]$ wget https://www.malwaredomainlist.com/hostslist/hosts.txt`
`--2016-01-09 12:45:13--  https://www.malwaredomainlist.com/hostslist/hosts.txt`
`Resolving www.malwaredomainlist.com (www.malwaredomainlist.com)... 143.215.130.61`
`Connecting to www.malwaredomainlist.com (www.malwaredomainlist.com)|143.215.130.61|:443... connected.`
`ERROR: cannot verify www.malwaredomainlist.com's certificate, issued by 'CN=Let\'s Encrypt Authority X1,O=Let\'s Encrypt,C=US':`
  `Unable to locally verify the issuer's authority.`
`To connect to www.malwaredomainlist.com insecurely, use `--no-check-certificate'.`

Apologize for mess up.