### PR TITLE
add service restart command for Arch Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,4 +131,6 @@ Open a Terminal and run with root privileges:
 
 **Fedora Linux**: `sudo systemctl restart NetworkManager.service`
 
-**Arch Linux/Manjaro**: `sudo systemctl restart NetworkManager.service`
+**Arch Linux/Manjaro with Network Manager**: `sudo systemctl restart NetworkManager.service`
+
+**Arch Linux/Manjaro with Wicd**: `sudo systemctl restart wicd.service`


### PR DESCRIPTION
Added the command for restarting the service when using Wicd, a popular alternative to NetworkManager.