### PR TITLE
add service restart command for Arch Linux

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -131,4 +131,6 @@ Open a Terminal and run with root privileges:
 
 **Fedora Linux**: `sudo systemctl restart NetworkManager.service`
 
-**Arch Linux/Manjaro**: `sudo systemctl restart NetworkManager.service`
+**Arch Linux/Manjaro with Network Manager**: `sudo systemctl restart NetworkManager.service`
+
+**Arch Linux/Manjaro with Wicd**: `sudo systemctl restart wicd.service`


### PR DESCRIPTION
Added the service restart instructions for the popular NetworkManager alternative Wicd on Arch Linux