### PR TITLE
Added dnsmasq and better messaging

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -407,42 +407,42 @@ def updateReadme(numberOfRules):
 
 def moveHostsFileIntoPlace(finalFile):
     if os.name == 'posix':
-        dnsFlushOccured = False
+        dnsCacheFound = False
         print ("Moving the file requires administrative privileges. " +
                "You might need to enter your password.")
         if subprocess.call(["/usr/bin/sudo", "cp", os.path.abspath(finalFile.name), "/etc/hosts"]):
             printFailure("Moving the file failed.")
         print ("Flushing the DNS Cache to utilize new hosts file...")
         if platform.system() == 'Darwin':
-            dnsFlushOccured = True
+            dnsCacheFound = True
             if subprocess.call(["/usr/bin/sudo", "killall", "-HUP", "mDNSResponder"]):
                 printFailure("Flushing the DNS Cache failed.")
         else:
             if os.path.isfile("/etc/rc.d/init.d/nscd"):
-                dnsFlushOccured = True
+                dnsCacheFound = True
                 if subprocess.call(["/usr/bin/sudo", "/etc/rc.d/init.d/nscd", "restart"]):
                     printFailure("Flushing the DNS Cache failed.")
                 else:
                     printSuccess("Flushing DNS by restarting nscd succeeded")
             if os.path.isfile("/usr/lib/systemd/system/NetworkManager.service"):
-                dnsFlushOccured = True
+                dnsCacheFound = True
                 if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "NetworkManager.service"]):
                     printFailure("Flushing the DNS Cache failed.")
                 else:
                     printSuccess("Flushing DNS by restarting NetworkManager succeeded")
             if os.path.isfile("/usr/lib/systemd/system/wicd.service"):
-                dnsFlushOccured = True
+                dnsCacheFound = True
                 if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "wicd.service"]):
                     printFailure("Flushing the DNS Cache failed.")
                 else:
                     printSuccess("Flushing DNS by restarting wicd succeeded")
             if os.path.isfile("/usr/lib/systemd/system/dnsmasq.service"):
-                dnsFlushOccured = True
+                dnsCacheFound = True
                 if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "dnsmasq.service"]):
                     printFailure("Flushing the DNS Cache failed.")
                 else:
                     printSuccess("Flushing DNS by restarting dnsmasq succeeded")
-            if not dnsFlushOccured:
+            if not dnsCacheFound:
                 printFailure("Unable to determine DNS management tool.")
     elif os.name == 'nt':
         print ("Automatically moving the hosts file in place is not yet supported.")

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -407,24 +407,43 @@ def updateReadme(numberOfRules):
 
 def moveHostsFileIntoPlace(finalFile):
     if os.name == 'posix':
+        dnsFlushOccured = False
         print ("Moving the file requires administrative privileges. " +
                "You might need to enter your password.")
         if subprocess.call(["/usr/bin/sudo", "cp", os.path.abspath(finalFile.name), "/etc/hosts"]):
             printFailure("Moving the file failed.")
         print ("Flushing the DNS Cache to utilize new hosts file...")
         if platform.system() == 'Darwin':
+            dnsFlushOccured = True
             if subprocess.call(["/usr/bin/sudo", "killall", "-HUP", "mDNSResponder"]):
                 printFailure("Flushing the DNS Cache failed.")
         else:
             if os.path.isfile("/etc/rc.d/init.d/nscd"):
+                dnsFlushOccured = True
                 if subprocess.call(["/usr/bin/sudo", "/etc/rc.d/init.d/nscd", "restart"]):
                     printFailure("Flushing the DNS Cache failed.")
+                else:
+                    printSuccess("Flushing DNS by restarting nscd succeeded")
             if os.path.isfile("/usr/lib/systemd/system/NetworkManager.service"):
+                dnsFlushOccured = True
                 if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "NetworkManager.service"]):
                     printFailure("Flushing the DNS Cache failed.")
+                else:
+                    printSuccess("Flushing DNS by restarting NetworkManager succeeded")
             if os.path.isfile("/usr/lib/systemd/system/wicd.service"):
+                dnsFlushOccured = True
                 if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "wicd.service"]):
                     printFailure("Flushing the DNS Cache failed.")
+                else:
+                    printSuccess("Flushing DNS by restarting wicd succeeded")
+            if os.path.isfile("/usr/lib/systemd/system/dnsmasq.service"):
+                dnsFlushOccured = True
+                if subprocess.call(["/usr/bin/sudo", "/usr/bin/systemctl", "restart", "dnsmasq.service"]):
+                    printFailure("Flushing the DNS Cache failed.")
+                else:
+                    printSuccess("Flushing DNS by restarting dnsmasq succeeded")
+            if not dnsFlushOccured:
+                printFailure("Unable to determine DNS management tool.")
     elif os.name == 'nt':
         print ("Automatically moving the hosts file in place is not yet supported.")
         print ("Please move the generated file to %SystemRoot%\system32\drivers\etc\hosts")


### PR DESCRIPTION
* Added restarting dnsmasq as a way to flush DNS cache (used by centos/rhel/fedora camp)
* Added success messages to services being restarted
* Added an error message if none of the conditions were met instead of
silently failing

I wasn't sure if we could change some of the `if os.path.isfile` statements to `elifs`? is there a case where multiple of these services would be enabled?

I did not really touch OSX side of the things as I am not sure what the
commands do and I do not have access to an OSX box.


