### PR TITLE
Fixed file not found error due to relative path

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -89,7 +89,7 @@ defaults = {
     "readmefilename" : "readme.md",
     "readmetemplate" : os.path.join(BASEDIR_PATH, "readme_template.md"),
     "readmedata" : {},
-    "readmedatafilename" : "readmeData.json",
+    "readmedatafilename" : os.path.join(BASEDIR_PATH, "readmeData.json"),
     "exclusionpattern" : "([a-zA-Z\d-]+\.){0,}",
     "exclusionregexs" : [],
     "exclusions" : [],


### PR DESCRIPTION
When updateHostFile.py is not run from the project directory we get a file not found error trying to find readmeData.json