### PR TITLE
Switch to https for adaway.org source

### DIFF
--- a/data/adaway.org/update.info
+++ b/data/adaway.org/update.info
@@ -1,1 +1,1 @@
-http://adaway.org/hosts.txt
+https://adaway.org/hosts.txt


### PR DESCRIPTION
Since adaway.org [does support ssl](https://github.com/Free-Software-for-Android/AdAway/blob/1000992c9fcd00a169b14b23e91d227d0cf6bfb2/hosts/hosts.txt#L8). It is still on ssl v1 though.