### PR TITLE
torrenty-org dot pl: phishing fake  site

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -18,10 +18,12 @@
 127.0.0.1 s.zkcdn.net
 127.0.0.1 specialsections.siteseer.ca
 127.0.0.1 stealthedeal.com
+127.0.0.1 torrenty-org.pl
 127.0.0.1 twitter.cm    # common misspelling
 127.0.0.1 ttwitter.com    # common misspelling and, besides, scumbags there.
 127.0.0.1 virtual.thewhig.com
 127.0.0.1 www.quickcash-system.com
 127.0.0.1 www.diptanuinfo.co.cc
+127.0.0.1 www.torrenty-org.pl
 #=====================================
 


### PR DESCRIPTION
fake registration charge

See: http://www.wykop.pl/link/3371947/torrenty-org-polski-katalog-torrentow/ (this is polish "reddit style" community portal)