### PR TITLE
StevenBlack:hosts fraud/phishing/scam website rule

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -8,6 +8,7 @@
 127.0.0.1 annualconsumersurvey.com
 127.0.0.1 apps.id.net
 127.0.0.1 canuck-method.com
+127.0.0.1 dobre-programy.pl
 127.0.0.1 www.canuck-method.com
 127.0.0.1 external.stealthedeal.com
 127.0.0.1 mackeeperapp.zeobit.com
@@ -23,6 +24,7 @@
 127.0.0.1 twitter.cm    # common misspelling
 127.0.0.1 ttwitter.com    # common misspelling and, besides, scumbags there.
 127.0.0.1 virtual.thewhig.com
+127.0.0.1 www.dobre-programy.pl
 127.0.0.1 www.quickcash-system.com
 127.0.0.1 www.diptanuinfo.co.cc
 127.0.0.1 www.torrenty-org.pl


### PR DESCRIPTION
Domain dobre-programy.pl is a fraud/scam/phishing website. Blocked as dangerous in ESET.
VALID and very good portal is dobreprogramy.pl (without minus in name).
@StevenBlack
More: http://www.dobreprogramy.pl/Niebezpieczna-podrobka-naszego-portalu-ponownie-przestrzegamy,News,33194.html