### PR TITLE
Removing cdn.tabnak.ir

### DIFF
--- a/hosts
+++ b/hosts
@@ -25040,7 +25040,6 @@ fe80::1%lo0 localhost
 0.0.0.0 cdn.stat.easydate.biz
 0.0.0.0 cdn.stickyadstv.com
 0.0.0.0 cdn.syn.verticalacuity.com
-0.0.0.0 cdn.tabnak.ir
 0.0.0.0 cdnt.yottos.com
 0.0.0.0 cdn.usabilitytracker.com
 #0.0.0.0 cdn.vidible.tv	#Breaks http://on.aol.com/


### PR DESCRIPTION
This completely breaks their site , they use same cdn for their news images and website stylesheets , more reasonable approach is adding this `http://cdn.tabnak.ir/files/adv/*` pattern to ad-blockers