### PR TITLE
Remove breitbart.com from the fakenews extension

### DIFF
--- a/extensions/fakenews/hosts
+++ b/extensions/fakenews/hosts
@@ -390,7 +390,6 @@
 0.0.0.0 www.bighairynews.com
 0.0.0.0 www.bizpacreview.com
 0.0.0.0 www.blastingnews.com
-0.0.0.0 www.breitbart.com
 0.0.0.0 www.burrardstreetjournal.com
 0.0.0.0 www.callthecops.net
 0.0.0.0 www.celebmaestro.com


### PR DESCRIPTION
Breitbart has about the same record as _The Huffington Post_, or _CNN.com_ which are not blocked.

Alternative to #250 