### PR TITLE
Add The Huffington Post to `fakenews` extension.

### DIFF
--- a/extensions/fakenews/hosts
+++ b/extensions/fakenews/hosts
@@ -131,6 +131,8 @@
 0.0.0.0 healthimpactnews.com
 0.0.0.0 heaviermetal.net
 0.0.0.0 henrymakow.com
+0.0.0.0 huffingtonpost.com
+0.0.0.0 huffingtonpost.ca
 0.0.0.0 humansarefree.com
 0.0.0.0 ihavethetruth.com
 0.0.0.0 ijr.com
@@ -438,6 +440,8 @@
 0.0.0.0 www.hangthebankers.com
 0.0.0.0 www.healthnutnews.com
 0.0.0.0 www.hermancain.com
+0.0.0.0 www.huffingtonpost.com
+0.0.0.0 www.huffingtonpost.ca
 0.0.0.0 www.humortimes.com
 0.0.0.0 www.huzlers.com
 0.0.0.0 www.ifactsviral.com


### PR DESCRIPTION
_The Huffington Post_ is about as fake as _Breitbart_, which is included in the list. It should be included for consistency.

Alternative to #249