### PR TITLE
Include 127.0.0.53 <hostname> to fix DNS issues in Ubuntu 17.04

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -413,6 +413,7 @@ def writeOpeningHeader(finalFile):
         writeData(finalFile, "0.0.0.0 0.0.0.0\n")
         if platform.system() == "Linux":
             writeData(finalFile, "127.0.1.1 " + socket.gethostname() + "\n")
+            writeData(finalFile, "127.0.0.53 " + socket.gethostname() + "\n")
         writeData(finalFile, "\n")
 
     preamble = os.path.join(BASEDIR_PATH, "myhosts")


### PR DESCRIPTION
Ubuntu 17.04 replaces dnsmasq with systemd-resolve which uses a different local IP address for domain name resolution.
By including this simple line of code we basically do the same what Issue #110 requested to fix Issue #109 but this time for systemd-resolve.