### PR TITLE
Patch promptForFlushDnsCache Bug

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -191,11 +191,13 @@ def promptForMoreCustomExclusions(question="Do you have more domains you want to
 
 
 def promptForFlushDnsCache():
-    if settings['auto']:
-        if settings['flushdnscache']:
-            flushDnsCache()
-    else:
-        if settings['flushdnscache'] or query_yes_no("Attempt to flush the DNS cache?"):
+    if settings["flushdnscache"]:
+        flushDnsCache()
+
+    if not settings["auto"]:
+        response = query_yes_no("Attempt to flush the DNS cache?")
+
+        if response == "yes":
             flushDnsCache()
 
 


### PR DESCRIPTION
Previously, it was checking if `query_yes_no` returned `False`, which does not happen, as the function only
returns `"yes"` or `"no"`. As a result, the check was always returning `True`, even when the user did not
want to flush the DNS cache.