### PR TITLE
Lift restriction on Python 3.x for makeHosts*

### DIFF
--- a/makeHosts
+++ b/makeHosts
@@ -1,26 +1,26 @@
 #!/bin/sh
 
 # These create various alternate hosts files by combining and adding the gambling, porn, and social media extensions.
-python3 updateHostsFile.py -a -z    -o alternates/gambling -e gambling
-python3 updateHostsFile.py -a -z -n -o alternates/porn -e porn
-python3 updateHostsFile.py -a -z -n -o alternates/social -e social
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews -e fakenews
+python updateHostsFile.py -a -z    -o alternates/gambling -e gambling
+python updateHostsFile.py -a -z -n -o alternates/porn -e porn
+python updateHostsFile.py -a -z -n -o alternates/social -e social
+python updateHostsFile.py -a -z -n -o alternates/fakenews -e fakenews
 
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-gambling -e fakenews gambling
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-porn -e fakenews porn
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-social -e fakenews social
-python3 updateHostsFile.py -a -z -n -o alternates/gambling-porn -e gambling porn
-python3 updateHostsFile.py -a -z -n -o alternates/gambling-social -e gambling social
-python3 updateHostsFile.py -a -z -n -o alternates/porn-social -e porn social
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling -e fakenews gambling
+python updateHostsFile.py -a -z -n -o alternates/fakenews-porn -e fakenews porn
+python updateHostsFile.py -a -z -n -o alternates/fakenews-social -e fakenews social
+python updateHostsFile.py -a -z -n -o alternates/gambling-porn -e gambling porn
+python updateHostsFile.py -a -z -n -o alternates/gambling-social -e gambling social
+python updateHostsFile.py -a -z -n -o alternates/porn-social -e porn social
 
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn -e fakenews gambling porn
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-social -e fakenews gambling social
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-porn-social -e fakenews porn social
-python3 updateHostsFile.py -a -z -n -o alternates/gambling-porn-social -e gambling porn social
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn -e fakenews gambling porn
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-social -e fakenews gambling social
+python updateHostsFile.py -a -z -n -o alternates/fakenews-porn-social -e fakenews porn social
+python updateHostsFile.py -a -z -n -o alternates/gambling-porn-social -e gambling porn social
 
-python3 updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn-social -e fakenews gambling porn social
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn-social -e fakenews gambling porn social
 
-python3 updateHostsFile.py -a -z -n
+python updateHostsFile.py -a -z -n
 
-# Update the readmes.
-python3 updateReadme.py
+# Update the README's.
+python updateReadme.py

--- a/makeHostsWindows.bat
+++ b/makeHostsWindows.bat
@@ -1,38 +1,27 @@
 @ECHO OFF
 TITLE Make Hosts
 
-if not exist "%WINDIR%\py.exe" (
-	ECHO :: ERROR :: Python 3.5 Runtime NOT FOUND...
-	ECHO :: ERROR :: Download and install lastest Python 3.5 for Windows from https://www.python.org/downloads/
-	ECHO :: ERROR :: Exit...
-	GOTO END
-) ELSE (
-	GOTO PY35RT
- )
-:PY35RT
-if not exist "%LOCALAPPDATA%\Programs\Python\Python35\Python35.dll" (
-	ECHO :: ERROR :: Python 3.5 Runtime NOT FOUND...
-	ECHO :: ERROR :: Download and install lastest Python 3.5 for Windows from https://www.python.org/downloads/
-	ECHO :: ERROR :: Exit...
-	GOTO END
-) ELSE (
-	ECHO :: INFO :: Python 3.5 Runtime was found!
-	ECHO :: INFO :: Running main script...
-	GOTO :UPDATES
- )
-:UPDATES
-	::These create various alternate hosts files by combining and adding the gambling, porn, and social media extensions.
-	updateHostsFile.py -a -z    -o alternates\gambling -e gambling
-	updateHostsFile.py -a -z -n -o alternates\porn -e porn
-	updateHostsFile.py -a -z -n -o alternates\social -e social
-	updateHostsFile.py -a -z -n -o alternates\gambling-porn -e gambling porn
-	updateHostsFile.py -a -z -n -o alternates\gambling-social -e gambling social
-	updateHostsFile.py -a -z -n -o alternates\porn-social -e porn social
-	updateHostsFile.py -a -z -n -o alternates\gambling-porn-social -e gambling porn social
-	updateHostsFile.py -a -z -n
+:: These create various alternate hosts files by combining and adding the gambling, porn, and social media extensions.
+python updateHostsFile.py -a -z    -o alternates/gambling -e gambling
+python updateHostsFile.py -a -z -n -o alternates/porn -e porn
+python updateHostsFile.py -a -z -n -o alternates/social -e social
+python updateHostsFile.py -a -z -n -o alternates/fakenews -e fakenews
 
-	::Update the readmes.
-	updateReadme.py
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling -e fakenews gambling
+python updateHostsFile.py -a -z -n -o alternates/fakenews-porn -e fakenews porn
+python updateHostsFile.py -a -z -n -o alternates/fakenews-social -e fakenews social
+python updateHostsFile.py -a -z -n -o alternates/gambling-porn -e gambling porn
+python updateHostsFile.py -a -z -n -o alternates/gambling-social -e gambling social
+python updateHostsFile.py -a -z -n -o alternates/porn-social -e porn social
 
-	GOTO END
-:END
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn -e fakenews gambling porn
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-social -e fakenews gambling social
+python updateHostsFile.py -a -z -n -o alternates/fakenews-porn-social -e fakenews porn social
+python updateHostsFile.py -a -z -n -o alternates/gambling-porn-social -e gambling porn social
+
+python updateHostsFile.py -a -z -n -o alternates/fakenews-gambling-porn-social -e fakenews gambling porn social
+
+python updateHostsFile.py -a -z -n
+
+::Update the README's.
+python updateReadme.py

--- a/readme_template.md
+++ b/readme_template.md
@@ -207,9 +207,6 @@ sudo dscacheutil -flushcache;sudo killall -HUP mDNSResponder
 
 ### Windows
 
-|`makeHostsWindows.bat` BATCH file will create various alternate hosts files by combining and adding the gambling, porn, and social media extensions. You need to be connected to the Internet. This file REQUIRED installed Python 3.5.x runtime environment in Windows System. Launch this file as normal user.|
-:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 |Run `updateHostsWindows.bat` BATCH file in Command Prompt with Administrator privileges in repository directory for easy update, replace hosts file and reload DNS cache in Windows System. You need to be connected to the Internet.|
 :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 

--- a/updateReadme.py
+++ b/updateReadme.py
@@ -5,11 +5,12 @@
 #
 # This Python script will update the readme files in this repo.
 
+from string import Template
+
 import os
 import sys
 import time
 import json
-from string import Template
 
 # Project Settings
 BASEDIR_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -17,9 +18,11 @@ README_TEMPLATE = os.path.join(BASEDIR_PATH, 'readme_template.md')
 README_FILENAME = 'readme.md'
 README_DATA_FILENAME = "readmeData.json"
 
+# Detecting Python 3 for version-dependent implementations
+PY3 = sys.version_info >= (3, 0)
+
 
 def main():
-
     s = Template('${description} | [Readme](https://github.com/StevenBlack/'
                  'hosts/blob/master/${location}readme.md) | '
                  '[link](https://raw.githubusercontent.com/StevenBlack/'
@@ -31,7 +34,7 @@ def main():
     with open(README_DATA_FILENAME, 'r') as f:
         data = json.load(f)
 
-    if sys.version_info >= (3, 0):
+    if PY3:
         keys = list(data.keys())
     else:
         keys = data.keys()
@@ -79,15 +82,61 @@ def main():
             for line in open(README_TEMPLATE):
                 line = line.replace('@GEN_DATE@', time.strftime("%B %d %Y",
                                                                 time.gmtime()))
-                line = line.replace('@EXTENSIONS@', extensions_str)
-                line = line.replace('@EXTENSIONS_HEADER@', extensions_header)
+                line = line.replace('@EXTENSIONS@',
+                                    decode_line(extensions_str))
+                line = line.replace('@EXTENSIONS_HEADER@',
+                                    decode_line(extensions_header))
                 line = line.replace('@NUM_ENTRIES@',
                                     "{:,}".format(data[key]["entries"]))
                 line = line.replace('@SUBFOLDER@',
-                                    os.path.join(data[key]["location"], ''))
-                line = line.replace('@TOCROWS@', toc_rows)
-                line = line.replace('@SOURCEROWS@', source_rows)
-                out.write(line)
+                                    decode_line(os.path.join(
+                                        data[key]["location"], '')))
+                line = line.replace('@TOCROWS@',
+                                    decode_line(toc_rows))
+                line = line.replace('@SOURCEROWS@',
+                                    decode_line(source_rows))
+                out.write(decode_line(line))
+
+
+def decode_line(line):
+    """
+    Python 2 compatible method for decoding unicode lines.
+
+    Parameters
+    ----------
+    line : str
+        The unicode string to decode.
+
+    Returns
+    -------
+    decoded_str : str
+        Decoded unicode string.
+    """
+
+    # Python 3.x has no unicode issues.
+    if PY3:
+        return line
+
+    # The biggest Python 2.x compatibility issue is the decoding of the
+    # en-dash. It either takes the form of u"\u2013" or "\xe2\x80\x93."
+    #
+    # This attempts to convert "\xe2\x80\x93" to u"\u2013" if necessary.
+    # If the character is already in the form of u"\u2013," this will
+    # raise an UnicodeEncodeError.
+    #
+    # In general, this line of code will allow us to convert unicode,
+    # UTF-8 encoded characters into pure unicode.
+    try:
+        line = line.decode("UTF-8")
+    except UnicodeEncodeError:
+        pass
+
+    # Replace u"\u2013" with the en-dash, so we now can decode.
+    #
+    # We can add additional "replace" lines in case there are other unicode
+    # literals that Python 2.x cannot handle.
+    line = line.replace(u"\u2013", "-")
+    return str(line.decode("UTF-8"))
 
 
 def cmp_keys(item):


### PR DESCRIPTION
1) `updateReadme.py` to be Python 2.x compatible.  Let's make all of the Python scripts cross-Python.

2) Make all of the `makeHosts*` scripts the same.  The scripts now generate the same host files regardless of  which platform you are on.

3) Lift the Python 3.5 restriction on the Windows `makeHosts` batch file.  Given that not all users use Python 3.5, this script is unnecessarily restrictive.  This change will only increase the number of users who can use it (I tested this with Python versions as far back as Python 3.3 as well as Python 2.7).

4) Remove the documentation on generating hosts files for Windows.  I don't know why this is necessary for Windows when I can run the other batch file just fine without it.