### PR TITLE
Lift Python 3.5.x restriction on updateHostsWindows.bat

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -210,8 +210,8 @@ sudo dscacheutil -flushcache;sudo killall -HUP mDNSResponder
 |`makeHostsWindows.bat` BATCH file will create various alternate hosts files by combining and adding the gambling, porn, and social media extensions. You need to be connected to the Internet. This file REQUIRED installed Python 3.5.x runtime environment in Windows System. Launch this file as normal user.|
 :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-|Run `updateHostsWindows.bat` BATCH file in Command Prompt with Administrator privileges in repository directory for easy update, replace hosts file and reload DNS cache in Windows System. You need to be connected to the Internet. This file REQUIRED installed Python 3.5.x runtime environment in Windows System.|
-:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|Run `updateHostsWindows.bat` BATCH file in Command Prompt with Administrator privileges in repository directory for easy update, replace hosts file and reload DNS cache in Windows System. You need to be connected to the Internet.|
+:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 |WARNING: Don't run these BAT files directly or from popup menu. You have been warned.|
 :--------------------------------------------------------------------------------------

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -1,77 +1,30 @@
-:: This script will create in first running backup of ORIGINAL/CURRENT hosts file in hosts.skel file.
-:: If hosts.skel file exists, then NEW copy with customized unified hosts file will be copied to proper path.
-:: Next DNS Cache will be refreshed.
-:: THIS BAT FILE WILL BE LAUNCHED WITH ADMINISTRATOR PRIVILEGES
+:: This script will create in first running backup of ORIGINAL/CURRENT
+:: hosts file in hosts.skel file.
+::
+:: If hosts.skel file exists, then the NEW copy with customized unified hosts
+:: file will be copied to proper path. Next, the DNS Cache will be refreshed.
+::
+:: THIS BAT FILE MUST BE LAUNCHED WITH ADMINISTRATOR PRIVILEGES
 @ECHO OFF
-SETLOCAL EnableDelayedExpansion
 TITLE Update Hosts
 
-VER | FINDSTR /L "5.1." > NUL
-IF %ERRORLEVEL% EQU 0 GOTO START
-
-VER | FINDSTR /L "5.2." > NUL
-IF %ERRORLEVEL% EQU 0 GOTO START
-
-CLS
-IF "%1"=="" GOTO CHECK_UAC
-IF "%1"=="start" GOTO START
-
-:CHECK_UAC
->nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"  
-If '%ERRORLEVEL%' NEQ '0' (
-    ECHO Requesting administrative privileges...
-    GOTO UAC_PROMPT
-) Else (
-    GOTO ADMIN
+:: Check if we are administrator. If not, exit immediately.
+>nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+if %ERRORLEVEL% NEQ 0 (
+    ECHO This script must be run with administrator privileges!
+    ECHO Please launch command prompt as administrator. Exiting...
+    EXIT /B 1
 )
 
-:UAC_PROMPT
-ECHO Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
-ECHO UAC.ShellExecute "%~s0", "", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
-"%TEMP%\getadmin.vbs"
-EXIT /B
-
-:ADMIN
-IF EXIST "%TEMP%\getadmin.vbs" ( DEL "%TEMP%\getadmin.vbs" )
-PUSHD "%CD%"
-CD /D "%~dp0"
-CD %CD%
-%COMSPEC% /c "updateHostsWindows.bat" start
-EXIT
-
-:START
-if not exist "%WINDIR%\py.exe" (
-	ECHO :: ERROR :: Python 3.5 Runtime NOT FOUND...
-	ECHO :: ERROR :: Download and install lastest Python 3.5 for Windows from https://www.python.org/downloads/
-	ECHO :: ERROR :: Exit...
-	GOTO END
-) ELSE ( 
-	GOTO PY35RT
-)
-
-:PY35RT
-if not exist "%LOCALAPPDATA%\Programs\Python\Python35\Python35.dll" (
-	ECHO :: ERROR :: Python 3.5 Runtime NOT FOUND...
-	ECHO :: ERROR :: Download and install lastest Python 3.5 for Windows from https://www.python.org/downloads/
-	ECHO :: ERROR :: Exit...
-	GOTO END
-) ELSE ( 
-	ECHO :: INFO :: Python 3.5 Runtime was found...
-	ECHO :: INFO :: Running main script...
-    GOTO DNSCHECK
-)
-
-:DNSCHECK
 if not exist "%WINDIR%\System32\drivers\etc\hosts.skel" (
 	COPY %WINDIR%\System32\drivers\etc\hosts %WINDIR%\System32\drivers\etc\hosts.skel
-	GOTO :CLEARDNS
 )
 
-:CLEARDNS
-updateHostsFile.py -a
-COPY hosts %WINDIR%\System32\drivers\etc\
-ipconfig /flushdns
-GOTO END
+:: Update hosts file
+python updateHostsFile.py -a
 
-:END
-ENDLOCAL
+:: Move new hosts file in-place
+COPY hosts %WINDIR%\System32\drivers\etc\
+
+:: Flush the DNS cache
+ipconfig /flushdns


### PR DESCRIPTION
1) Lift the Python 3.5.x restriction on `updateHostsWindows.bat`.  Per the existing documentation, `updateHostsFile.py` is cross-Python compatible.

2) Greatly reduce the checks for administrator privileges.  We should be running this file as administrator on command prompt, so we shouldn't be requesting administrator access if that isn't the case (case in point: when I run the original batch file as is on normal command prompt, I get caught in an infinite loop that attempts to request administrator access).  Rather, we should just kill the script.