### PR TITLE
Tighten regex rule to discard IP address as hostname

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -501,7 +501,8 @@ def normalize_rule(rule):
         The rule string with spelling and spacing reformatted.
     """
 
-    result = re.search(r'^[ \t]*(\d+\.\d+\.\d+\.\d+)\s+([\w\.-]+)(.*)', rule)
+    result = re.search(r'^\s*(\d{1,3}\.){3}\d{1,3}\s+([\w\.-]+[a-zA-Z])(.*)',
+                       rule)
     if result:
         hostname, suffix = result.group(2, 3)
 


### PR DESCRIPTION
The regex rule to normalize host data in `normalize_rule` needs to be adjusted to avoid spurious entries like so:
```
0.0.0.0 130.211.230.53
```

While at it, just went ahead and tighten the regex rule to match valid IPv4 addresses only.