### PR TITLE
Honor whitelist exclusion only for domain or subdomain match

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -471,7 +471,7 @@ def remove_dups_and_excl(merge_file):
         # Normalize rule
         hostname, normalized_rule = normalize_rule(stripped_rule)
         for exclude in exclusions:
-            if exclude in line:
+            if re.search('[\s\.]' + re.escape(exclude) + '\s', line):
                 write_line = False
                 break
 


### PR DESCRIPTION
* Whitelisting `s.youtube.com` should not whitelist `ads.youtube.com`; but can whitelist `a.s.youtube.com`
* Whitelisting `twitter.com` should not whitelist `ttwitter.com` or `twitter.com.au`; but can whitelist `a.twitter.com`