### PR TITLE
Drop nose dependency on Travis

### DIFF
--- a/ci/install_conda_env.sh
+++ b/ci/install_conda_env.sh
@@ -5,4 +5,4 @@ conda create -n hosts python=$PYTHON_VERSION || exit 1
 source activate hosts
 
 echo "Installing packages..."
-conda install mock nose flake8
+conda install mock flake8

--- a/ci/test_repo.sh
+++ b/ci/test_repo.sh
@@ -3,4 +3,4 @@
 echo "Running unittests..."
 source activate hosts
 
-nosetests
+python testUpdateHostsFile.py

--- a/readme_template.md
+++ b/readme_template.md
@@ -12,10 +12,6 @@ To run unit tests, in the top level directory, just run:
 
     python testUpdateHostsFile.py
 
-You can also install `nose` with `pip` and then just run:
-
-    nosetests
-
 **Note** if you are using Python 2, you must first install the `mock` library:
 
     pip install mock


### PR DESCRIPTION
Nose is not a well-supported library anymore (see <a href="https://nose.readthedocs.io/en/latest/">here</a>).

`unittest.main()` is sufficient for our purposes.  Note, we can still note that it is possible in the documentation, but we shouldn't rely on it for our testing machines.