### PR TITLE
Refactor out source data updating

### DIFF
--- a/updateReadme.py
+++ b/updateReadme.py
@@ -23,8 +23,10 @@ PY3 = sys.version_info >= (3, 0)
 
 
 def main():
-    s = Template('${description} | [Readme](https://github.com/StevenBlack/hosts/blob/master/${location}readme.md) | '
-                 '[link](https://raw.githubusercontent.com/StevenBlack/hosts/master/${location}hosts) | '
+    s = Template('${description} | [Readme](https://github.com/StevenBlack/'
+                 'hosts/blob/master/${location}readme.md) | '
+                 '[link](https://raw.githubusercontent.com/StevenBlack/'
+                 'hosts/master/${location}hosts) | '
                  '${fmtentries} | '
                  '[link](http://sbc.io/hosts/${location}hosts)')
     with open(README_DATA_FILENAME, 'r') as f:


### PR DESCRIPTION
I was going to refactor `settings` out of `create_initial_file`, when I found that there was this entire block of logic in there updating the `sourcedata` field in `settings` that could be abstracted out into its own method, thereby partially addressing what I had set out to do.

Follow-up to #379.