### PR TITLE
Added "urldelivery.com" and "rocks.io"

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -67,8 +67,11 @@
 127.0.0.1 www.mywot.com
 127.0.0.1 www.mywot.net
 127.0.0.1 www.torrenty-org.pl
+127.0.0.1 urldelivery.com
+127.0.0.1 www.urldelivery.com
+127.0.0.1 rocks.io
+127.0.0.1 www.rocks.io
 # Analytics
-
 127.0.0.1 analysis.polarisoffice.com
 127.0.0.1 analytics-digit-in.cdn.ampproject.org
 127.0.0.1 analytics.cloudron.io


### PR DESCRIPTION
I ran across these on my network today and did some research. "urldelivery.com" is known for delivering viruses and "rocks.io" delivers data mining scripts. "rocks.io" may or may not fit into the new analytics section, but someone better at analyzing such scripts would be better suited to determine that than I.