### PR TITLE
Correct licenses for FadeMind host files

### DIFF
--- a/data/add.2o7Net/update.json
+++ b/data/add.2o7Net/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.2o7Net/hosts",
-    "license": "MIT"
+    "license": "GPLv3+"
 }

--- a/data/add.Dead/update.json
+++ b/data/add.Dead/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Dead/hosts",
-    "license": "MIT"
+    "license": "GPLv3+"
 }

--- a/data/add.Risk/update.json
+++ b/data/add.Risk/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts",
-    "license": "MIT"
+    "license": "GPLv3+"
 }

--- a/data/add.Spam/update.json
+++ b/data/add.Spam/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts",
-    "license": "MIT"
+    "license": "GPLv3+"
 }


### PR DESCRIPTION
The FadeMind project lists a MIT license, however it did not create
several host files it provides. Instead, the copying.txt file
in the source:

http://hostsfile.org/Downloads/BadHosts.unx.zip

lists LGPL as the license. Without specifying the version, it
implies the latest. This is denoted by GPLv3+.