### PR TITLE
Add license for Clefspeare13/pornhosts

### DIFF
--- a/extensions/porn/clefspeare13/update.json
+++ b/extensions/porn/clefspeare13/update.json
@@ -4,5 +4,6 @@
     "homeurl": "https://github.com/Clefspeare13/pornhosts",
     "frequency": "occasional",
     "issues": "https://github.com/Clefspeare13/pornhosts/issues",
-    "url": "https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts"
+    "url": "https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts",
+    "license": "MIT"
 }


### PR DESCRIPTION
This project adopted the MIT license. See the following for details:

https://github.com/Clefspeare13/pornhosts/issues/13