### PR TITLE
Remove license for UncheckyAds

### DIFF
--- a/data/UncheckyAds/update.json
+++ b/data/UncheckyAds/update.json
@@ -4,6 +4,5 @@
     "homeurl": "https://github.com/FadeMind/hosts.extras",
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
-    "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts",
-    "license": "MIT"
+    "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts"
 }


### PR DESCRIPTION
The FadeMind lists the MIT license, however that project only hosts
the UncheckyAds host list and did not create it. Instead, that list
is based on content from unchecky.com.

I was unable to determine the license of that content, and am removing
the license to prevent someone from accidentally violating the
actual license by using the content.