### PR TITLE
dobreprogramy scam/fraud variants

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -18,6 +18,7 @@
 127.0.0.1 support.apple.com-notice.info
 127.0.0.1 www.support.apple.com-notice.info
 127.0.0.1 dobre-programy.pl
+127.0.0.1 dobreprogramy.pro
 127.0.0.1 www.canuck-method.com
 127.0.0.1 com-notice.info
 127.0.0.1 www.com-notice.info

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -18,6 +18,7 @@
 127.0.0.1 support.apple.com-notice.info
 127.0.0.1 www.support.apple.com-notice.info
 127.0.0.1 dobre-programy.pl
+127.0.0.1 dobre-programy.xyz
 127.0.0.1 dobreprogramy.pro
 127.0.0.1 www.canuck-method.com
 127.0.0.1 com-notice.info


### PR DESCRIPTION
@StevenBlack Please merge new scam/fraud URLs based on **dobreprogramy.pl** mark (IT news and download center like softpedia). Installers from **dobreprogramy.pro** site wanted passwords from SMS Premium for unlock FAKE installers. They are showed in Google after search popular keywords results.

Official Statement:
https://www.dobreprogramy.pl/b.munro/Ostrzegamy-przed-probami-podszywania-sie-pod-dobreprogramy.pl,84334.html

IT Security news:
https://niebezpiecznik.pl/post/naciagacze-premium-sms-chca-zarobic-na-firefoksie/

Best Regards

Tomasz