### PR TITLE
Remove kiwifarms.net from StevenBlack list

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -111,7 +111,6 @@
 127.0.0.1 joyreactor.cc
 127.0.0.1 anime.reactor.cc
 127.0.0.1 miner.pr0gramm.com
-127.0.0.1 kiwifarms.net
 127.0.0.1 kisshentai.net 
 127.0.0.1 coinerra.com
 127.0.0.1 crypto-loot.com


### PR DESCRIPTION
kiwifarms.net does not contain on-by-default cryptocurrency miner anymore