### PR TITLE
Update LICENSE and CI

### DIFF
--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -21,5 +21,6 @@ conda config --set ssl_verify false || exit 1
 conda config --set always_yes true --set changeps1 false || exit 1
 
 echo "Updating Miniconda"
+conda update conda
 conda update --all
 conda info -a || exit 1

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2017 Steven Black
+Copyright © 2018 Steven Black
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in


### PR DESCRIPTION
1) It's 2018
2) `conda update --all` no longer applies to `conda` itself.
    `conda update conda` needs to be explicitly called.