### PR TITLE
Possible scam sites

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -23,6 +23,7 @@
 127.0.0.1 www.canuck-method.com
 127.0.0.1 com-notice.info
 127.0.0.1 www.com-notice.info
+127.0.0.1 largeloot.com
 127.0.0.1 letitbefaster.website
 127.0.0.1 login.dotomi.com
 127.0.0.1 login.dotomi.net
@@ -36,6 +37,7 @@
 127.0.0.1 hosted.stats.com
 127.0.0.1 hosted.stats.com.edgesuite.net
 127.0.0.1 howupdateworks.amazingupdates4youtoday.website
+127.0.0.1 mysterysnooper.com
 127.0.0.1 mywot.com
 127.0.0.1 mywot.net
 127.0.0.1 onlineusagesurveys.com


### PR DESCRIPTION
Been seeing links to sites with the domain `largeloot.com`. Right now, `http://spark.largeloot.com` appears to redirect to `https://www.mysterysnooper.com/`

This may be a mystery shopper scam, but I'm not entirely sure. If it helps, I came across `http://spark.largeloot.com` on craigslist's gigs section.