### PR TITLE
Phishy

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -11,6 +11,7 @@
 127.0.0.1 breaksurvey.com
 127.0.0.1 data.cnn.com
 127.0.0.1 canuck-method.com
+127.0.0.1 ceromobi.club
 127.0.0.1 com-notice.info
 127.0.0.1 www.com-notice.info
 127.0.0.1 apple.com-notice.info


### PR DESCRIPTION
Presently, `http://play.ceromobi.club/raffle/en/vs2-opt/index.html` will present you with a phony facebook game. Actually, I just one $1000.

It then directs you to another domain: `consumerproductsusa.com`. After submitting an email address, it then took me to `amarktflow.com`.

In response, I got this charming response (LOL): `https://www.dropbox.com/s/u0jy0xtm1cdjsfd/Screenshot%202018-01-20%2012.38.54.png?dl=0`

It's gets scammier after that.

What do you know about those other two domains?