### PR TITLE
Remove Hardcoded Offset in Compression

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -667,6 +667,7 @@ def compress_file(input_file, target_ip, output_file):
     input_file.seek(0)  # reset file pointer
     write_data(output_file, '\n')
 
+    target_ip_len = len(target_ip)
     lines = [target_ip]
     lines_index = 0
     for line in input_file.readlines():
@@ -674,7 +675,8 @@ def compress_file(input_file, target_ip, output_file):
 
         if line.startswith(target_ip):
             if lines[lines_index].count(' ') < 9:
-                lines[lines_index] += ' ' + line[7:line.find('#')].strip()
+                lines[lines_index] += ' ' \
+                    + line[target_ip_len:line.find('#')].strip()
             else:
                 lines[lines_index] += '\n'
                 lines.append(line[:line.find('#')].strip())


### PR DESCRIPTION
# Description
An offset of `7` was hardcoded in the function `compress_file`, presumably to skip over the default target IP address of `0.0.0.0` in a `hosts` file. However, this causes problems when the default is overridden using the `--ip` or `-i` flag, causing visibly garbled output in the generated hosts file.

# Steps to Reproduce
```
git clone https://github.com/StevenBlack/hosts.git
cd hosts/
python3 updateHostsFile.py -a -n -c -i 127.0.0.1
tail -1 hosts
```

## Expected Output
```
127.0.0.1 trackersimulator.org eviltracker.net do-not-tracker.org
```

## Actual Output
```
127.0.0.1 trackersimulator.org .1 eviltracker.net .1 do-not-tracker.org
```
Notice the garbage `.1` strings in between.

# Fix
Calculate length of target IP at runtime.