### PR TITLE
malwaredomainlist.com is available over HTTPS

### DIFF
--- a/data/malwaredomainlist.com/update.json
+++ b/data/malwaredomainlist.com/update.json
@@ -1,9 +1,9 @@
 {
     "name": "Malware Domain List",
     "description": "Malware Domain List is a non-commercial community project.",
-    "homeurl": "http://www.malwaredomainlist.com/",
+    "homeurl": "https://www.malwaredomainlist.com/",
     "frequency": "weekly",
-    "issues": "http://www.malwaredomainlist.com/contact.php",
-    "url": "http://www.malwaredomainlist.com/hostslist/hosts.txt",
+    "issues": "https://www.malwaredomainlist.com/contact.php",
+    "url": "https://www.malwaredomainlist.com/hostslist/hosts.txt",
     "license": "'can be used for free by anyone'"
 }


### PR DESCRIPTION
It is currently being fetched over [HTTP](http://www.malwaredomainlist.com/hostslist/hosts.txt "Malware Domain List over HTTP"), although it is readily available over [HTTPS](https://www.malwaredomainlist.com/hostslist/hosts.txt "Malware Domain List over HTTPS").