### PR TITLE
Removed Cryptominer Domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -217,49 +217,6 @@
 127.0.0.1 yashin.alphonso.tv
 127.0.0.1 zico.alphonso.tv
 
-# JS based cryptocurrency mining sites
-127.0.0.1 server.jsecoin.com
-127.0.0.1 jsecoin.com
-127.0.0.1 www.jsecoin.com
-127.0.0.1 load.jsecoin.com
-127.0.0.1 listat.biz
-127.0.0.1 mataharirama.xyz
-127.0.0.1 static.reasedoper.pw
-127.0.0.1 lmodr.biz
-127.0.0.1 minecrunch.co
-127.0.0.1 minero.pw
-127.0.0.1 ppoi.org
-127.0.0.1 kissdoujin.com
-127.0.0.1 joyreactor.cc
-127.0.0.1 anime.reactor.cc
-127.0.0.1 miner.pr0gramm.com
-127.0.0.1 kisshentai.net
-127.0.0.1 coinerra.com
-127.0.0.1 crypto-loot.com
-127.0.0.1 minemytraffic.com
-127.0.0.1 coinnebula.com
-127.0.0.1 coinminerz.com
-127.0.0.1 cryptonight.wasm
-127.0.0.1 monerominer.rocks
-127.0.0.1 www.monerominer.rocks
-127.0.0.1 deepc.cc
-127.0.0.1 www.deepc.cc
-127.0.0.1 cryptocoinjs.com
-127.0.0.1 www.cryptocoinjs.com
-127.0.0.1 www.2giga.link
-127.0.0.1 2giga.link
-127.0.0.1 www.crypto-loot.com
-127.0.0.1 coinhive.com
-127.0.0.1 www.coinhive.com
-127.0.0.1 coin-have.com
-127.0.0.1 www.coin-have.com
-127.0.0.1 hashforcash.us
-127.0.0.1 www.hashforcash.us
-127.0.0.1 rocks.io
-127.0.0.1 www.rocks.io
-127.0.0.1 bjorksta.men
-127.0.0.1 www.bjorksta.men
-
 # Ads and tracking on Xiaomi devices
 127.0.0.1 api.ad.xiaomi.com
 127.0.0.1 api.admob.xiaomi.com


### PR DESCRIPTION
Before this PR can be approved, the following list of domains should be discussed as they were not found on @ZeroDot1's list. I've also included some comments.

    # JS based cryptocurrency mining sites
    127.0.0.1 joyreactor.cc
    127.0.0.1 coinminerz.com
    127.0.0.1 cryptonight.wasm # Probably mistaken as a URL, but this is actually the name of a WebAssembly binary package used by miners
    127.0.0.1 www.deepc.cc # deepc.cc is on CoinBlockerList
    127.0.0.1 cryptocoinjs.com
    127.0.0.1 www.cryptocoinjs.com
    127.0.0.1 www.bjorksta.men # bjorksta.men is on CoinBlockerList