### PR TITLE
Encoding (#520) review

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1407,7 +1407,27 @@ class DomainToIDNA(Base):
 
             self.assertEqual(actual, expected)
 
-    def test_single_line_with_comment_at_the_end(self):
+    def test_multiple_space_as_separator(self):
+        # Test with multiple space as separator.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0      " + self.domains[i]).decode('utf-8')
+            expected = "0.0.0.0      " + self.expected_domains[i]
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+    def test_multiple_tabs_as_separator(self):
+        # Test with multiple tabls as separator.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0\t\t\t\t\t\t" + self.domains[i]).decode('utf-8')
+            expected = "0.0.0.0\t\t\t\t\t\t" + self.expected_domains[i]
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+    def test_line_with_comment_at_the_end(self):
         # Test with a space as separator.
         for i in range(len(self.domains)):
             data = (b"0.0.0.0 " + self.domains[i] + b" # Hello World") \
@@ -1429,7 +1449,56 @@ class DomainToIDNA(Base):
 
             self.assertEqual(actual, expected)
 
-    def test_single_line_without_prefix(self):
+        # Test with tabulation as separator of domain and comment.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0\t" + self.domains[i] + b"\t # Hello World") \
+                .decode('utf-8')
+            expected = "0.0.0.0\t" + self.expected_domains[i] + \
+                "\t # Hello World"
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+        # Test with space as separator of domain and tabulation as separator
+        # of comments.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0 " + self.domains[i] + b"  \t # Hello World") \
+                .decode('utf-8')
+            expected = "0.0.0.0 " + self.expected_domains[i] + \
+                "  \t # Hello World"
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+        # Test with multiple space as seprator of domain and space and
+        # tabulation as separator or comments.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0     " + self.domains[i] + b" \t # Hello World") \
+                .decode('utf-8')
+            expected = "0.0.0.0     " + self.expected_domains[i] + \
+                " \t # Hello World"
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+        # Test with multiple tabulations as seprator of domain and space and
+        # tabulation as separator or comments.
+        for i in range(len(self.domains)):
+            data = (b"0.0.0.0\t\t\t" +
+                    self.domains[i] +
+                    b" \t # Hello World") \
+                        .decode('utf-8')
+            expected = "0.0.0.0\t\t\t" + self.expected_domains[i] + \
+                " \t # Hello World"
+
+            actual = domain_to_idna(data)
+
+            self.assertEqual(actual, expected)
+
+    def test_line_without_prefix(self):
         for i in range(len(self.domains)):
             data = self.domains[i].decode('utf-8')
             expected = self.expected_domains[i]

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1159,26 +1159,47 @@ def domain_to_idna(line):
     """
 
     if not line.startswith('#'):
-        for separator in ['\t', ' ']:
-            comment = ''
+        tabs = '\t'
+        space = ' '
 
-            if separator in line:
-                splited_line = line.split(separator)
-                if '#' in splited_line[1]:
-                    index_comment = splited_line[1].find('#')
+        tabs_position, space_position = (line.find(tabs), line.find(space))
 
-                    if index_comment > -1:
-                        comment = splited_line[1][index_comment:]
+        if tabs_position > -1 and space_position > -1:
+            if space_position < tabs_position:
+                separator = space
+            else:
+                separator = tabs
+        elif not tabs_position == -1:
+            separator = tabs
+        elif not space_position == -1:
+            separator = space
+        else:
+            separator = ''
 
-                        splited_line[1] = splited_line[1] \
-                            .split(comment)[0] \
-                            .encode("IDNA").decode("UTF-8") + \
-                            comment
+        if separator:
+            splited_line = line.split(separator)
 
-                splited_line[1] = splited_line[1] \
-                    .encode("IDNA") \
-                    .decode("UTF-8")
-                return separator.join(splited_line)
+            index = 1
+            while index < len(splited_line):
+                if splited_line[index]:
+                    break
+                index += 1
+
+            if '#' in splited_line[index]:
+                index_comment = splited_line[index].find('#')
+
+                if index_comment > -1:
+                    comment = splited_line[index][index_comment:]
+
+                    splited_line[index] = splited_line[index] \
+                        .split(comment)[0] \
+                        .encode("IDNA").decode("UTF-8") + \
+                        comment
+
+            splited_line[index] = splited_line[index] \
+                .encode("IDNA") \
+                .decode("UTF-8")
+            return separator.join(splited_line)
         return line.encode("IDNA").decode("UTF-8")
     return line.encode("UTF-8").decode("UTF-8")
 


### PR DESCRIPTION
Hello everybody, 
I hope that everybody goes right out here!

First of all sorry for forcing this review after being so bad in #520 as I probably could write the following commits along with #520. 

Secondly **thanks to** @FadeMind for #526 which forced me to rewrite my previously submitted function in order to pass more tests. 
@FadeMind **your PR is great** but it does not resolve all the issue behind what you discovered as if we apply your patch, another issue can appear and can take us into a never-ending loop of fixing the same thing. 
The explanation behind that is that **I was dumb** when writing that line you changed. Indeed, if we reverse the list today, tomorrow we will still have to reverse it once more to fill a case like the one I mentioned: 

```
0.0.0.0(tabulations)domain(spaces & tabulations)# comments`
```
**I'm really sorry if I offended you and anyone else. I did not mean to offend anyone. My apologies if I did.**

Finally to explain the issue discovered by @FadeMind 
I'll invite you to download [ŧhis file](https://raw.githubusercontent.com/StevenBlack/hosts/318389b08f122ca6863e12f11f9771a3cd3bd09d/testUpdateHostsFile.py) and test it against the latest `updateHostsFile.py` ([cf](https://github.com/StevenBlack/hosts/tree/v1.1.0)) to understand what changed.

If you do not have time for that the discovered issue is the following:


If we have a line which looks like the following
```
0.0.0.0(space)domain(tabulation(s) and spaces)# comments
```
We got an issue because **I did not considerate that a tabulation can be after the domain**. Which is why I say that **#526 is not bad** as **the reversion solves the problem by splitting space before the tabulation**.

To resolve that I first **includes new tests to pass**.
Then instead of splitting directly according to a list reading order, I decided to **search which one of tabs or space comes first** in the string with (https://github.com/StevenBlack/hosts/commit/8405f87edb6a1fb9346409daaf5aee39b565355f#diff-0e14783994b4ea380231d48b421ae128R1165):

```
        tabs_position, space_position = (line.find(tabs), line.find(space))

        if tabs_position > -1 and space_position > -1:
            if space_position < tabs_position:
                separator = space
            else:
                separator = tabs
        elif not tabs_position == -1:
            separator = tabs
        elif not space_position == -1:
            separator = space
        else:
            separator = ''
```

In between, I discovered an issue which is: once we split if we have multiple occurrences of the separator (tabs or space) **we were not capable of converting it**. So I fixed that part by introducing a pseudo-index search with(https://github.com/StevenBlack/hosts/commit/8405f87edb6a1fb9346409daaf5aee39b565355f#diff-0e14783994b4ea380231d48b421ae128R1182):

```
            index = 1
            while index < len(splited_line):
                if splited_line[index]:
                    break
                index += 1
```

The rest stay almost the same.

Cheers,
Nissar.