### PR TITLE
Remove Superfluous Check for Zero-Length List

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -620,9 +620,8 @@ def update_all_sources(source_data_filename, host_filename):
             updated_file = get_file_by_url(update_url)
 
             # spin the transforms as required
-            if len(update_transforms) > 0:
-                for transform in update_transforms:
-                    updated_file = transform_methods[transform](updated_file)
+            for transform in update_transforms:
+                updated_file = transform_methods[transform](updated_file)
 
             # get rid of carriage-return symbols
             updated_file = updated_file.replace("\r", "")


### PR DESCRIPTION
Checking for zero-length is not necessary here as iterating over a zero-length list is perfectly valid, and produces exactly zero iterations, matching the intended behaviour without an extra check.