### PR TITLE
StreamingAds

### DIFF
--- a/data/SpotifyAds/update.json
+++ b/data/SpotifyAds/update.json
@@ -1,0 +1,9 @@
+{
+    "name": "SpotifyAds",
+    "description": "Spotify ads sources based on Spotify-Ad-free content with fixes.",
+    "homeurl": "https://github.com/FadeMind/hosts.extras",
+    "frequency": "occasionally",
+    "issues": "https://github.com/FadeMind/hosts.extras/issues",
+    "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/SpotifyAds/hosts",
+    "license": "MIT"
+}


### PR DESCRIPTION
@StevenBlack  
Please notice: domain `spclient.wg.spotify.com` **must be blocked against ads**. See: https://github.com/StevenBlack/hosts/issues/270

I tested on my side. Works perfectly. Hosts blocking ads and did not affecting Web Player and Main App. Did not tested on mobile (but I using adguard so... :sweat_smile: ) 