### PR TITLE
Blocked ads on Hotstar streaming apps

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -421,6 +421,30 @@
 0.0.0.0 vidutils.taboola.com
 0.0.0.0 wf.taboola.com
 
+# Block ads on Hotstar streaming app by @anudeepND
+0.0.0.0 app-measurement.com
+0.0.0.0 agl.hotstar.com
+0.0.0.0 adserver.adtech.de
+0.0.0.0 segment.hotstar.com
+0.0.0.0 service.videoplaza.tv
+0.0.0.0 cdn.segment.com
+0.0.0.0 cdn.mxpnl.com
+0.0.0.0 js-agent.newrelic.com
+0.0.0.0 sentry.io
+0.0.0.0 sb.scorecardresearch.com
+0.0.0.0 in-star.videoplaza.tv
+0.0.0.0 segment.hotstar.com
+0.0.0.0 js-agent.newrelic.com
+0.0.0.0 hotstar.worldgravity.com
+0.0.0.0 service.videoplaza.tv
+0.0.0.0 cdn.mxpnl.com
+0.0.0.0 cdn.segment.com
+0.0.0.0 ssl.widgets.webengage.com
+0.0.0.0 ap-sonar.sociomantic.com
+0.0.0.0 chuknu.sokrati.com
+0.0.0.0 tag.hockeycurve.com
+0.0.0.0 agl-intl.hotstar.com
+
 # Spam domains
 # If your software is able, the below domains and all subdomains should be blocked
 127.0.0.1 angiemktg.com


### PR DESCRIPTION
Google play link: [Hotstar](https://play.google.com/store/apps/details?id=in.startv.hotstar)
Website: [Hotstar](http://hotstar.com)

Hotstar is a popular streaming service with over 100 million downloads on Google play and over 300 million+ users . 
This PR will:
1. Blocks all kinds of video/banner ads and pixel tracking in both app and website.
2. Doesn't cause any slowdowns.
3. Doesn't block any legitimate service.
4. Does not cause any delay while loading the videos.