### PR TITLE
Typing error in fix for: "Adblocker warning in spiegel.de #536"

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -366,7 +366,7 @@
 0.0.0.0 sf-3.st.adtekmedia.com
 0.0.0.0 sf3.east.kobenetwork.com
 0.0.0.0 sionicmedia.com
-0.0.0.0.spiegel-de.spiegel.de
+0.0.0.0 spiegel-de.spiegel.de
 0.0.0.0 ssp.face2trade.com
 0.0.0.0 static.elixmedia.com
 0.0.0.0 tracker.clickopon.com


### PR DESCRIPTION
Typing error: "0.0.0.0.spiegel-de.spiegel.de" should be "0.0.0.0 spiegel-de.spiegel.de".