### PR TITLE
Remove sentry.io from StevenBlack list

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -435,7 +435,6 @@
 0.0.0.0 cdn.segment.com
 0.0.0.0 cdn.mxpnl.com
 0.0.0.0 js-agent.newrelic.com
-0.0.0.0 sentry.io
 0.0.0.0 sb.scorecardresearch.com
 0.0.0.0 in-star.videoplaza.tv
 0.0.0.0 segment.hotstar.com


### PR DESCRIPTION
https://sentry.io is an error tracking tool, not an ad site.

I believe it was added by mistake from https://github.com/StevenBlack/hosts/pull/557