### PR TITLE
Analytics.publitas.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -6,6 +6,7 @@
 127.0.0.1 2468.go2cloud.org
 127.0.0.1 adsmws.cloudapp.net
 127.0.0.1 androidads23.adcolony.com
+127.0.0.1 analytics.publitas.com
 127.0.0.1 annualconsumersurvey.com
 127.0.0.1 apps.id.net
 127.0.0.1 breaksurvey.com


### PR DESCRIPTION
Adding analytics.publitas.com as it is used as data Analytics.
Discussion > https://github.com/StevenBlack/hosts/issues/576