### PR TITLE
Windows 10 'Connected User Experience' Telemetry

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -451,6 +451,12 @@
 0.0.0.0 tag.hockeycurve.com
 0.0.0.0 agl-intl.hotstar.com
 
+# Windows 10 'Connected User Experience' Telemetry
+# Connected User Experience and Diagnostic component endpoint for Windows 10, version 1709 or earlier
+v10.vortex-win.data.microsoft.com
+# Connected User Experience and Diagnostic component endpoint for operating systems older than Windows 10
+vortex-win.data.microsoft.com
+
 # Spam domains
 # If your software is able, the below domains and all subdomains should be blocked
 127.0.0.1 angiemktg.com

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -453,9 +453,9 @@
 
 # Windows 10 'Connected User Experience' Telemetry
 # Connected User Experience and Diagnostic component endpoint for Windows 10, version 1709 or earlier
-v10.vortex-win.data.microsoft.com
+0.0.0.0 v10.vortex-win.data.microsoft.com
 # Connected User Experience and Diagnostic component endpoint for operating systems older than Windows 10
-vortex-win.data.microsoft.com
+0.0.0.0 vortex-win.data.microsoft.com
 
 # Spam domains
 # If your software is able, the below domains and all subdomains should be blocked


### PR DESCRIPTION
As written over here https://docs.microsoft.com/en-us/windows/configuration/configure-windows-diagnostic-data-in-your-organization and there https://docs.microsoft.com/en-us/windows/deployment/update/windows-analytics-get-started

Windows uses various domains for telemetry and your list already got some Windows 10 telemetry hosts.
Problem is the most important ones are not there yet. These should be added immediately.

More external information:

http://www.pcministry.com/win10_telemetry/summary_stats_and_conclusions/#domain-names