### PR TITLE
Add cws.conviva.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -13,6 +13,7 @@
 127.0.0.1 data.cnn.com
 127.0.0.1 canuck-method.com
 127.0.0.1 com-notice.info
+127.0.0.1 cws.conviva.com
 127.0.0.1 www.com-notice.info
 127.0.0.1 apple.com-notice.info
 127.0.0.1 www.apple.com-notice.info


### PR DESCRIPTION
Add cws.conviva.com Analytics Architecture.

"Video AI Platform
A Unique Measurement and Analytics Architecture for the Next Generation of TV"

Tested. Won't affects videos.