### PR TITLE
Block ads on Voot streaming app

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -473,6 +473,10 @@
 0.0.0.0 static.clmbtech.com
 0.0.0.0 api.branch.io
 
+# Block ads on Voot streaming app @anudeepND
+0.0.0.0 in-viacom18.videoplaza.tv
+0.0.0.0 dev.appboy.com
+0.0.0.0 register.appsflyer.com
 
 # Windows 10 'Connected User Experience' Telemetry
 # Connected User Experience and Diagnostic component endpoint for Windows 10, version 1709 or earlier


### PR DESCRIPTION
Voot is a streaming app used to stream Indian TV shows etc. It's ranked top 6 in Entrainment app by Google Play.

1. `videoplaza.tv`
It's an advertising company, they provide video ad solutions. 

2. `appsflyer.com`
Mobile App Tracking & Attribution Analytics platform.

3. `appboy.com`
Mobile marketing company based in New York City.

This PR will:

1. Blocks all kinds of video/banner ads and pixel tracking in both app and website.
2. Doesn't cause any slowdowns.
3. Doesn't block any legitimate service.
4. Does not cause any delay while loading the videos.

