### PR TITLE
Telemetry - Windows 10 version 1803

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -534,6 +534,8 @@
 0.0.0.0 register.appsflyer.com
 
 # Windows 10 'Connected User Experience' Telemetry
+# Connected User Experience and Diagnostic component endpoint for use with Windows 10, version 1803
+0.0.0.0 v10.events.data.microsoft.com
 # Connected User Experience and Diagnostic component endpoint for Windows 10, version 1709 or earlier
 0.0.0.0 v10.vortex-win.data.microsoft.com
 # Connected User Experience and Diagnostic component endpoint for operating systems older than Windows 10


### PR DESCRIPTION
New telemetry endpoint for Windows 10, version 1803, also known as Windows 10 April 2018 Update.
As written: https://docs.microsoft.com/en-us/windows/deployment/update/windows-analytics-get-started
This one should be added immediately.