### PR TITLE
Deletion of deprecation warning (Fix of #597)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-lxml==4.1.1
-beautifulsoup4==4.6.0
 mock==2.0.0
+beautifulsoup4==4.6.0

--- a/requirements_python2.txt
+++ b/requirements_python2.txt
@@ -1,3 +1,2 @@
 mock==2.0.0
-lxml==4.1.1
 beautifulsoup4==4.6.0

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -23,7 +23,6 @@ import tempfile
 import time
 from glob import glob
 
-import lxml  # noqa: F401
 from bs4 import BeautifulSoup
 
 # Detecting Python 3 for version-dependent implementations
@@ -1229,7 +1228,7 @@ def get_file_by_url(url):
 
     try:
         f = urlopen(url)
-        soup = BeautifulSoup(f.read(), 'lxml').get_text()
+        soup = BeautifulSoup(f.read(), 'html.parser').get_text()
         return '\n'.join(list(map(domain_to_idna, soup.split('\n'))))
     except Exception:
         print("Problem getting file: ", url)


### PR DESCRIPTION
Please note that this patch do the following:
 * Deletion of lxml from dependencies
 * Usage of `html.parser` (Python built-in parser) instead of `lxml` as the parser used by BeautifulSoup

Explanation:
  As the maintainer of the `lxml` package is aware of that warning but it still not fixed, I prefer to use `html.parser` which is the built-in Python HTML parser.
  This way, we avoid the `lxml` deprecation message mentioned by #597.