### PR TITLE
Kuik adware domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -529,6 +529,9 @@
 0.0.0.0 onlineapi.youappi.com
 0.0.0.0 static.youappi.com
 0.0.0.0 ad.adapter.kaffnet.com
+0.0.0.0 kuikdelivery.com
+0.0.0.0 tripan.me
+0.0.0.0 d-and-h.com
 
 # Block ads on Hotstar streaming app by @anudeepND
 0.0.0.0 app-measurement.com


### PR DESCRIPTION
[Kuik: a simple yet annoying piece of adware](https://blog.malwarebytes.com/threat-analysis/2018/05/kuik-simple-yet-annoying-piece-adware/)

