### PR TITLE
Rollbar Error Tracking and Crash Reporting

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -620,4 +620,10 @@
 0.0.0.0 token.rubiconproject.com
 0.0.0.0 fc.yahoo.com
 0.0.0.0 pr-bh.ybp.yahoo.com
+
+# Error tracking and crash reporting
+rollbar.com
+www.rollbar.com
+api.rollbar.com
+
 #=====================================


### PR DESCRIPTION
Hey, I'd like a second opinion on this before it gets approved. I caught it being called from a Chromecast and it appears to be an error tracking and crash reporting service. Obviously it includes analytics of some kind in order to do the debugging, but I am not sure if others will think this counts as analytics or not. If anyone else has a Chromecast and can test blocking this, as well, and let me know the results, that would also be most appreciative just to make sure it's not a necessary service. It is a telemetry service and I know we're in agreement about the Windows telemetry services, so I am assuming this would count.