### PR TITLE
Corrected format of Rollbar domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -622,8 +622,8 @@
 0.0.0.0 pr-bh.ybp.yahoo.com
 
 # Error tracking and crash reporting
-rollbar.com
-www.rollbar.com
-api.rollbar.com
+0.0.0.0 rollbar.com
+0.0.0.0 www.rollbar.com
+0.0.0.0 api.rollbar.com
 
 #=====================================


### PR DESCRIPTION
The black hole address was absent, causing the script to not read them.