### PR TITLE
Chromecast anlytics - "channel.status.request.url"

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -621,6 +621,9 @@
 0.0.0.0 fc.yahoo.com
 0.0.0.0 pr-bh.ybp.yahoo.com
 
+# Chromecast analytics
+0.0.0.0 channel.status.request.url
+
 # Error tracking and crash reporting
 0.0.0.0 rollbar.com
 0.0.0.0 www.rollbar.com


### PR DESCRIPTION
Can another Chromecast user second this before being approved? From my research it's completely useless to the function of the Chromecast and some ISPs even spoof this domain to intercept the traffic, probably to gain analytics about what you're streaming since different ISPs are competing with different streaming services.