### PR TITLE
Android devices ship with pre-installed malware

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -84,7 +84,6 @@
 127.0.0.1 www.urldelivery.com
 127.0.0.1 files.ctnet4.space
 127.0.0.1 apps3.cointraffic.io
-
 127.0.0.1 cfvod.kaltura.com
 127.0.0.1 metrics.brightcove.com
 127.0.0.1 ping.chartbeat.net
@@ -98,7 +97,6 @@
 127.0.0.1 tvmds.tvpassport.com
 127.0.0.1 stats.wp.com
 127.0.0.1 4436230.fls.doubleclick.net
-
 127.0.0.1 aoredi.com
 127.0.0.1 imysurvey.com
 127.0.0.1 gamblerush.com
@@ -536,7 +534,8 @@
 0.0.0.0 cosiloon.com
 0.0.0.0 abc.cosiloon.com
 0.0.0.0 app.storage.yunvm.com
-
+0.0.0.0 abd.cosiloon.com
+0.0.0.0 pull-3045.kxcdn.com
 
 # Block ads on Hotstar streaming app by @anudeepND
 0.0.0.0 app-measurement.com

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -532,6 +532,11 @@
 0.0.0.0 kuikdelivery.com
 0.0.0.0 tripan.me
 0.0.0.0 d-and-h.com
+0.0.0.0 www.cosiloon.com
+0.0.0.0 cosiloon.com
+0.0.0.0 abc.cosiloon.com
+0.0.0.0 app.storage.yunvm.com
+
 
 # Block ads on Hotstar streaming app by @anudeepND
 0.0.0.0 app-measurement.com


### PR DESCRIPTION
A detailed report can be found [here](https://blog.avast.com/android-devices-ship-with-pre-installed-malware)