### PR TITLE
Include lightswitch05 hosts files list, adding 989 more domains.

### DIFF
--- a/data/lightswitch05/update.json
+++ b/data/lightswitch05/update.json
@@ -1,0 +1,9 @@
+{
+    "name": "lightswitch05",
+    "description": "Block ad and tracking domains.",
+    "homeurl": "https://github.com/lightswitch05/hosts",
+    "frequency": "occasionally",
+    "issues": "https://github.com/lightswitch05/hosts/issues",
+    "url": "https://raw.githubusercontent.com/lightswitch05/hosts/master/ads-and-tracking-extended.txt",
+    "license": "Apache-2.0"
+}


### PR DESCRIPTION
Hello, and thank you for providing this wonderful project!

I've been maintaining a hosts file on GitHub to make it easier to sync my custom block list across devices. There are certainly duplicates, but as of this morning my list contains 989 unique domains not found in this project. The block list only contains domains used for advertising and tracking - no social or fake news, etc. When I find a new domain, I use certificate transparency logs to find more subdomains. This helps overcome the lack of wildcards.

Anyways, I thought you might be interested in pulling my list into yours🍻 