### PR TITLE
UC apps telemetry 

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -593,6 +593,21 @@
 0.0.0.0 dev.appboy.com
 0.0.0.0 register.appsflyer.com
 
+# UC apps telemetry
+0.0.0.0 adn.insight.ucweb.com
+0.0.0.0 convhkmp.taboola.com
+0.0.0.0 feedback.uc.cn
+0.0.0.0 g.alicdn.com
+0.0.0.0 gj.applog.uc.cn
+0.0.0.0 gj.track.uc.cn
+0.0.0.0 gjtrack.ucweb.com
+0.0.0.0 imprhkmp.taboola.com
+0.0.0.0 in-gmtdmp.mookie1.com
+0.0.0.0 instory-log.ucnews.ucweb.com
+0.0.0.0 logserver.insight.ucweb.com
+0.0.0.0 click.union.ucweb.com
+0.0.0.0 sg.mmstat.com
+
 # Windows 10 'Connected User Experience' Telemetry
 # Connected User Experience and Diagnostic component endpoint for use with Windows 10, version 1803
 0.0.0.0 v10.events.data.microsoft.com


### PR DESCRIPTION
Tracking domains which are used in UC apps like UC browser, UC news etc.  #493 