### PR TITLE
Introduction of `Start xx` and `End xxx`

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -632,8 +632,12 @@ def create_initial_file():
     # spin the sources for the base file
     for source in recursive_glob(settings["datapath"],
                                  settings["hostfilename"]):
+
+        start = "# Start {}\n".format(os.path.basename(os.path.dirname(source)))
+        end = "# End {}\n".format(os.path.basename(os.path.dirname(source)))
+
         with open(source, "r") as curFile:
-            write_data(merge_file, curFile.read())
+            write_data(merge_file, start + curFile.read() + end)
 
     # spin the sources for extensions to the base file
     for source in settings["extensions"]:


### PR DESCRIPTION
This patch fix #644.

# Warning before merging

As there was too much different information between #644 and https://github.com/StevenBlack/hosts/issues/634#issuecomment-394546359. I take this occasion for clarification.

So before merging we may have to be clear about the marker to use as:

Steven @StevenBlack suggested:
> Asking because, for parsing purposes, I know that `# start {source name}` and # end `{source name}` seems easier. 

@dnmTX suggested:
>```
> #  KADhosts Start
> domain.com
> domain.com
> domain.com
> # KADhosts End
>```

And I did: 

```
# Start StevenBlack 
data
# End StevenBlack

# Start UncheckyAds
data
# End UncheckyAds
```

Cheers,
Nissar
