### PR TITLE
Fix default encoding

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import time
 from glob import glob
+from imp import reload
 
 import lxml  # noqa: F401
 from bs4 import BeautifulSoup

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -23,12 +23,12 @@ import tempfile
 import time
 from glob import glob
 
+import lxml  # noqa: F401
+from bs4 import BeautifulSoup
+
 # Set default encoding to UTF8
 reload(sys)
 sys.setdefaultencoding('utf8')
-
-import lxml  # noqa: F401
-from bs4 import BeautifulSoup
 
 # Detecting Python 3 for version-dependent implementations
 PY3 = sys.version_info >= (3, 0)

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -22,24 +22,24 @@ import sys
 import tempfile
 import time
 from glob import glob
-from imp import reload
 
 import lxml  # noqa: F401
 from bs4 import BeautifulSoup
-
-# Set default encoding to UTF8
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 # Detecting Python 3 for version-dependent implementations
 PY3 = sys.version_info >= (3, 0)
 
 if PY3:
     from urllib.request import urlopen
+    from importlib import reload
     raw_input = input
 else:  # Python 2
     from urllib2 import urlopen
     raw_input = raw_input  # noqa
+
+# Set default encoding to UTF8
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 # Syntactic sugar for "sudo" command in UNIX / Linux
 if platform.system() == "OpenBSD":

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -23,6 +23,10 @@ import tempfile
 import time
 from glob import glob
 
+# Set default encoding to UTF8
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 import lxml  # noqa: F401
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
On macOS High Sierra, running built-in python 2.7.10, the script `updateHostsFile.py` throws:

![image](https://user-images.githubusercontent.com/7253814/41524280-5a5cb77c-72b3-11e8-97ba-b98ac1194a8f.png)

This is happening because the program doesn't ensure UTF8 as default, although in some places it's done ad-hoc in the shape of `.decode("UTF-8")` calls.

This PR ensures the default encoding is set to UTF8, so it's less likely the program might fail on different environments.

After this change:
![image](https://user-images.githubusercontent.com/7253814/41524262-4066d442-72b3-11e8-8ea6-f9356d80baec.png)

Hope this helps.