### PR TITLE
update readme to include instructions for clearing dns cache on Mint

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -304,6 +304,8 @@ Open a Terminal and run with root privileges:
 
 **Debian/Ubuntu** `sudo /etc/rc.d/init.d/nscd restart`
 
+**Linux Mint** `sudo /etc/init.d/dns-clean start`
+
 **Linux with systemd**: `sudo systemctl restart network.service`
 
 **Fedora Linux**: `sudo systemctl restart NetworkManager.service`


### PR DESCRIPTION
Linux Mint is in the tree of Debian/Ubuntu and so you'd expect that those instructions would work. However Mint has its own configuration. As Mint is one of the most popular distros, probably worth having.