### PR TITLE
Added RedShell analytics domains to blocked hosts.

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -882,5 +882,9 @@
 0.0.0.0 xn--adspace-kvg.ero-advertising.com
 0.0.0.0 zww.ero-advertising.com
 0.0.0.0 _thums.ero-advertising.com
+0.0.0.0 redshell.io
+0.0.0.0 api.redshell.io
+0.0.0.0 treasuredata.com
+0.0.0.0 api.treasuredata.com
 
 #=====================================


### PR DESCRIPTION
RedShell is a spyware/analytics platform embeded without noticing the user in several aplications (mostly games as far as I can tell) and allowing for the tracking of users even outside of said applications.


Blocking their domains through hosts files seems to prevent said tracking.