### PR TITLE
Update cws.conviva.com tracking method

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -17,8 +17,6 @@
 127.0.0.1 consumerproductsusa.com
 127.0.0.1 ceromobi.club
 127.0.0.1 com-notice.info
-127.0.0.1 cws.conviva.com
-#*.cws.conviva.com
 127.0.0.1 www.com-notice.info
 127.0.0.1 apple.com-notice.info
 127.0.0.1 www.apple.com-notice.info
@@ -644,6 +642,8 @@
 #*.angiemktg.com
 127.0.0.1 weconfirmyou.com
 #*.weconfirmyou.com
+127.0.0.1 cws.conviva.com
+#*.cws.conviva.com
 
 # These stink-up yahoo finance
 0.0.0.0 beap-bc.yahoo.com

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -18,6 +18,7 @@
 127.0.0.1 ceromobi.club
 127.0.0.1 com-notice.info
 127.0.0.1 cws.conviva.com
+#*.cws.conviva.com
 127.0.0.1 www.com-notice.info
 127.0.0.1 apple.com-notice.info
 127.0.0.1 www.apple.com-notice.info


### PR DESCRIPTION
As shown at https://github.com/StevenBlack/hosts/pull/587 cws.conviva.com is already present.
The problem is that the conviva.com tracking method has changed so the blacklist should be changed.

Previously, cws.conviva.com tracked non-generic by cws.conviva.com.
This has changed to unique, specific per user via be43a77aab46b0546578grgrtgr3d4ba6506d488.cws.conviva.com (example).

Various programs like Ad-blockers have the possibility to use wildcards.
In order to keep it so generally working, it seems wise to block the entire domain + sub-domains if the user block software is able to support wildcards.

I tested it with Horizon (local TV service provider), and even though I opted for opt-out of analytics viewing data, it is still being tracked.
Therefore this one should be added immediately.

@ScriptTiger Found [your wild-card entries over here](https://github.com/StevenBlack/hosts/pull/490). 
Could you please take a look at my wild-card commit, whether it is working or not. Thanks.