### PR TITLE
Update malwaredomainlist and someonewhocares to use https.

### DIFF
--- a/data/malwaredomainlist.com/update.json
+++ b/data/malwaredomainlist.com/update.json
@@ -1,9 +1,9 @@
 {
     "name": "Malware Domain List",
     "description": "Malware Domain List is a non-commercial community project.",
-    "homeurl": "http://www.malwaredomainlist.com/",
+    "homeurl": "https://www.malwaredomainlist.com/",
     "frequency": "weekly",
-    "issues": "http://www.malwaredomainlist.com/contact.php",
-    "url": "http://www.malwaredomainlist.com/hostslist/hosts.txt",
+    "issues": "https://www.malwaredomainlist.com/contact.php",
+    "url": "https://www.malwaredomainlist.com/hostslist/hosts.txt",
     "license": "'can be used for free by anyone'"
 }

--- a/data/someonewhocares.org/update.json
+++ b/data/someonewhocares.org/update.json
@@ -1,9 +1,9 @@
 {
-    "name": "Dan Pollock – [someonewhocares](http://someonewhocares.org)",
+    "name": "Dan Pollock – [someonewhocares](https://someonewhocares.org)",
     "description": "How to make the internet not suck (as much).",
-    "homeurl": "http://someonewhocares.org/hosts/",
+    "homeurl": "https://someonewhocares.org/hosts/",
     "frequency": "frequently",
     "issues": "hosts@someonewhocares.org",
-    "url": "http://someonewhocares.org/hosts/zero/hosts",
+    "url": "https://someonewhocares.org/hosts/zero/hosts",
     "license": "non-commercial with attribution"
 }


### PR DESCRIPTION
Update malwaredomainlist and someonewhocares to use https. This leaves 'MVPS hosts file (http://winhelp2002.mvps.org/)' as the only non-secure source. Interestingly enough, the domain has a valid cert, but all pages results in a 404 - must be some configuration issues.