### PR TITLE
Skip flake8 check on Python on 2.7

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -3,4 +3,8 @@
 echo "Linting repository..."
 source activate hosts
 
-flake8 --max-line-length 120
+if [ "$PYTHON_VERSION" = "2.7" ]; then
+    echo "Skipping flake8 because it is broken on Python $PYTHON_VERSION"
+else
+    flake8 --max-line-length 120
+fi


### PR DESCRIPTION
`flake8` is broken with Python 2.7 (see [here](https://travis-ci.org/StevenBlack/hosts/jobs/411106788#L596)), but we have all other builds linting, so not an issue for us.