### PR TITLE
Update docs to say we support Python 3.5+

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -1,5 +1,5 @@
 ----
-**Take Note!**  This version of the Hosts file generator, and tests, are for Python 3.7+ only.
+**Take Note!**  This version of the Hosts file generator, and tests, are for Python 3.5+ only.
 
 ----
 


### PR DESCRIPTION
Python 3.5 and 3.6 are still alive and well supported.