### PR TITLE
Analytics.ff.avast.com / CCleaner / Avast

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -5,6 +5,7 @@
 0.0.0.0 30-day-change.com
 0.0.0.0 2468.go2cloud.org
 0.0.0.0 adservice.google.nl
+0.0.0.0 analytics.ff.avast.com
 0.0.0.0 adsmws.cloudapp.net
 0.0.0.0 androidads23.adcolony.com
 0.0.0.0 analytics.publitas.com


### PR DESCRIPTION
Even though I opted for opt-out of analytics viewing data, usage is still being tracked.
As the "Help improve CCleaner by sending anonymous usage data" is automatically checked again at every restart.

This is confirmed by the firewall logs.
Therefore this one should be added immediately.

No host-block-list contains this analytics entry, hence this commit.