### PR TITLE
Telemetry - Windows 10 1803 - September update

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -675,6 +675,8 @@
 0.0.0.0 v10.vortex-win.data.microsoft.com
 # Connected User Experience and Diagnostic component endpoint for operating systems older than Windows 10
 0.0.0.0 vortex-win.data.microsoft.com
+# Connected User Experience and Diagnostic component endpoint for use with Windows versions that have KB4458469 installed (Windows 10 1803 with the september 2018 update and higher)
+0.0.0.0 v10c.events.data.microsoft.com
 
 # Office 2016 'Connected User Experience' Telemetry
 # OneNote Telemetry Service


### PR DESCRIPTION
v10c.events.data.microsoft.com

New telemetry endpoint for Windows 10, version 1803, also known as Windows 10 April 2018 Update.
Since KB4458469, Windows 10 1803 with September 2018 update and higher.

As written: https://docs.microsoft.com/en-us/windows/deployment/update/windows-analytics-get-started
This one should be added immediately.