### PR TITLE
Python version 3.5 sufficient

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Data for extensions is stored in the [`extensions`](https://github.com/StevenBla
 
 ## Generate your own unified hosts file
 
-To generate your own unified hosts file you will need Python 3.7 or later.
+To generate your own unified hosts file you will need Python 3.5 or later.
 
 First install the dependencies with:
 

--- a/readme_template.md
+++ b/readme_template.md
@@ -61,7 +61,7 @@ Data for extensions is stored in the [`extensions`](https://github.com/StevenBla
 
 ## Generate your own unified hosts file
 
-To generate your own unified hosts file you will need Python 3.7 or later.
+To generate your own unified hosts file you will need Python 3.5 or later.
 
 First install the dependencies with:
 


### PR DESCRIPTION
Python version 3.7 is actually not required for building one's own
hosts file. According to the CI configuration, any version >= 3.5
should work.

Tested with Python 3.6.6 on Ubuntu 18.04.

Fixes issue #820