### PR TITLE
Block locale-based Reddit hosts

### DIFF
--- a/alternates/social/hosts
+++ b/alternates/social/hosts
@@ -56951,6 +56951,8 @@ ff02::3 ip6-allhosts
 0.0.0.0 amp-reddit-com.cdn.ampproject.org
 0.0.0.0 old.reddit.com
 0.0.0.0 new.reddit.com
+0.0.0.0 reddit.map.fastly.net
+
 # blacklist
 #
 # The contents of this file (containing a listing of additional domains in


### PR DESCRIPTION
Reddit provides localized version of the website by prepending the URL with a locale like `de.reddit.com` or `de-at.reddit.com`. It would be quite inefficient to block all of the hosts according to the
`[a-z]{2}(-[a-z]{2})?.reddit.com` pattern. But, all of this hosts get resolved to the CDN host reddit.map.fastly.net, which can be blocked. Example:

```
$ ping de-at.reddit.com
PING reddit.map.fastly.net (151.101.113.140) 56(84) bytes of data.
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=1 ttl=57 time=30.9 ms
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=2 ttl=57 time=30.5 ms
```

```
$ ping pt-br.reddit.com
PING reddit.map.fastly.net (151.101.113.140) 56(84) bytes of data.
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=1 ttl=57 time=33.1 ms
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=2 ttl=57 time=30.6 ms
```

Fixes #776