### PR TITLE
Exclude massive logout sites

### DIFF
--- a/extensions/logout/update.json
+++ b/extensions/logout/update.json
@@ -1,0 +1,9 @@
+{
+    "name": "Boris' collection of logout jokes domains",
+    "description": "A collection of category-specific host files.",
+    "homeurl": "https://github.com/borisschapira/hostfiles",
+    "frequency": "occasional",
+    "issues": "https://github.com/borisschapira/hostfiles/issues",
+    "url": "https://raw.githubusercontent.com/borisschapira/hostfiles/master/logout-host",
+    "license": "MIT"
+}

--- a/readme_template.md
+++ b/readme_template.md
@@ -57,7 +57,7 @@ Extensions are optional, and are added to the base hosts file.  Extensions are c
 For example, you may want to block porn domains in addition to the adware and malware we block by default.  That hosts file is stored in the porn subfolder of the [`alternates`](https://github.com/StevenBlack/hosts/tree/master/alternates) folder.  
 
 Data for extensions is stored in the [`extensions`](https://github.com/StevenBlack/hosts/tree/master/extensions) folder. You manage extensions by curating the
-[`extensions`](https://github.com/StevenBlack/hosts/tree/master/extensions)  folder tree where you will find the data for `fakenews`, `social`, `gambling`, and `porn` extension data that we maintain and provide for you.
+[`extensions`](https://github.com/StevenBlack/hosts/tree/master/extensions)  folder tree where you will find the data for `fakenews`, `social`, `gambling`, `porn`, and `logout` extension data that we maintain and provide for you.
 
 ## Generate your own unified hosts file
 


### PR DESCRIPTION
Some sites automatically disconnect users, without their consent, from a number of sites. In addition to being unethical, these practical jokes can lead to the loss of the current contributions on these platforms. I propose to exclude them through a new `logout` extension.