### PR TITLE
Exclude massive logout sites

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -949,6 +949,10 @@
 0.0.0.0 best2017games.com
 0.0.0.0 www.bet365.com
 
+# Massive logout sites 
+0.0.0.0 theannoyingsite.com
+0.0.0.0 superlogout.github.io
+
 # Other
 0.0.0.0 api.userstyles.org
 0.0.0.0 hrtya.com


### PR DESCRIPTION
Some sites automatically disconnect users, without their consent, from a number of sites. In addition to being unethical, these practical jokes can lead to the loss of the current contributions on these platforms. I propose to exclude them.