### PR TITLE
Added more Google ad domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -322,6 +322,8 @@
 0.0.0.0 soperson.com
 0.0.0.0 talk99.cn
 0.0.0.0 www.talk99.cn
+0.0.0.0 googlesyndication.com
+0.0.0.0 tpc.googlesyndication.com
 
 # Ads and tracking on Xiaomi devices
 0.0.0.0 api.ad.xiaomi.com


### PR DESCRIPTION
Added "tpc.googlesyndication.com" and "googlesyndication.com," caught being used to host YouTube ads.