### PR TITLE
Telemetry - Office - November 2018 update

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -690,6 +690,8 @@
 0.0.0.0 nexusrules.officeapps.live.com
 # Telemetry and Reporting Service for Office apps
 0.0.0.0 telemetry.firstpartyapps.oaspapps.com
+# Telemetry Reporting 
+0.0.0.0 browser.pipe.aria.microsoft.com
 
 # Spam domains
 # If your software is able, the below domains and all subdomains should be blocked


### PR DESCRIPTION
browser.pipe.aria.microsoft.com

New telemetry endpoint for Office: Word, Powerpoint, Excel and Outlook (WPXO).

As written in the official Microsoft documentation: https://docs.microsoft.com/nl-nl/office365/enterprise/network-requests-in-office-2016-for-mac
This one should be added immediately.