### PR TITLE
CoinBlockerList: using main hosts file

### DIFF
--- a/data/CoinBlockerList/update.json
+++ b/data/CoinBlockerList/update.json
@@ -4,6 +4,6 @@
     "homeurl": "https://gitlab.com/ZeroDot1/CoinBlockerLists",
     "frequency": "frequently",
     "issues": "https://gitlab.com/ZeroDot1/CoinBlockerLists/issues",
-    "url": "https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser",
+    "url": "https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/hosts",
     "license": "GPLv3"
 }


### PR DESCRIPTION
@StevenBlack  IMHO better is using main big hosts file for prevent cryptominers instead of basic browser hosts file (smaller). Works for me.