### PR TITLE
How Facebook tracks you on Android

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -962,6 +962,7 @@
 0.0.0.0 cradver.livejasmin.com
 0.0.0.0 freeadult.games
 0.0.0.0 goooooooooogle.com
+0.0.0.0 graph.facebook.com
 
 # See Issue #844 – Windows telemetry servers – https://github.com/StevenBlack/hosts/issues/844
 alpha.telemetry.microsft.com


### PR DESCRIPTION
How Facebook tracks you on Android: (even if you don’t have a Facebook account)

Research has shown how 42.55 percent of free apps on the Google Play store could share data
with Facebook.

As can ben reviewed in the report below. 
Privacy International strongly recommends to block: graph.facebook.com

This one should be added immediately.

Story: 

Research has shown how 42.55 percent of free apps on the Google Play store could share data
with Facebook, making Facebook the second most prevalent third-party tracker after Google’s parent
company Alphabet.1 In this report, Privacy International illustrates what this data sharing looks like in
practice, particularly for people who do not have a Facebook account.

https://privacyinternational.org/sites/default/files/2018-12/How%20Apps%20on%20Android%20Share%20Data%20with%20Facebook%20-%20Privacy%20International%202018.pdf

https://fahrplan.events.ccc.de/congress/2018/Fahrplan/system/event_attachments/attachments/000/003/716/original/How_Facebook_tracks_users_on_Android_%28even_if_they_don't_have_a_Facebook_account%29-3.pdf

APP examples:

https://privacyinternational.org/node/2498
https://privacyinternational.org/node/2646
https://privacyinternational.org/node/2476