### PR TITLE
Specify encoding to UTF-8 when opening source file

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -527,7 +527,7 @@ def update_sources_data(sources_data, **sources_params):
     source_data_filename = sources_params["sourcedatafilename"]
 
     for source in recursive_glob(sources_params["datapath"], source_data_filename):
-        update_file = open(source, "r", encoding="utf8")
+        update_file = open(source, "r", encoding="UTF-8")
         update_data = json.load(update_file)
         sources_data.append(update_data)
         update_file.close()
@@ -586,7 +586,7 @@ def update_all_sources(source_data_filename, host_filename):
     all_sources = recursive_glob("*", source_data_filename)
 
     for source in all_sources:
-        update_file = open(source, "r", encoding="utf8")
+        update_file = open(source, "r", encoding="UTF-8")
         update_data = json.load(update_file)
         update_file.close()
         update_url = update_data["url"]
@@ -631,7 +631,7 @@ def create_initial_file():
         start = "# Start {}\n\n".format(os.path.basename(os.path.dirname(source)))
         end = "# End {}\n\n".format(os.path.basename(os.path.dirname(source)))
 
-        with open(source, "r", encoding="utf8") as curFile:
+        with open(source, "r", encoding="UTF-8") as curFile:
             write_data(merge_file, start + curFile.read() + end)
 
     # spin the sources for extensions to the base file

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -527,7 +527,7 @@ def update_sources_data(sources_data, **sources_params):
     source_data_filename = sources_params["sourcedatafilename"]
 
     for source in recursive_glob(sources_params["datapath"], source_data_filename):
-        update_file = open(source, "r")
+        update_file = open(source, "r", encoding="utf8")
         update_data = json.load(update_file)
         sources_data.append(update_data)
         update_file.close()
@@ -586,7 +586,7 @@ def update_all_sources(source_data_filename, host_filename):
     all_sources = recursive_glob("*", source_data_filename)
 
     for source in all_sources:
-        update_file = open(source, "r")
+        update_file = open(source, "r", encoding="utf8")
         update_data = json.load(update_file)
         update_file.close()
         update_url = update_data["url"]
@@ -631,7 +631,7 @@ def create_initial_file():
         start = "# Start {}\n\n".format(os.path.basename(os.path.dirname(source)))
         end = "# End {}\n\n".format(os.path.basename(os.path.dirname(source)))
 
-        with open(source, "r") as curFile:
+        with open(source, "r", encoding="utf8") as curFile:
             write_data(merge_file, start + curFile.read() + end)
 
     # spin the sources for extensions to the base file


### PR DESCRIPTION
Hi there, new user here. 

I am just a normal user using this tool to update hosts file. In my Windows machine, I have trouble updating hosts file running `updateHostsWindows.bat`.

```
... (All the Updating sorce data\xxx messages)
Updating source data\malwaredomainlist.com from https://www.malwaredomainlist.com/hostslist/hosts.txt
Updating source data\mvps.org from http://winhelp2002.mvps.org/hosts.txt
Traceback (most recent call last):
  File "updateHostsFile.py", line 1525, in <module>
    main()
  File "updateHostsFile.py", line 164, in main
    update_all_sources(source_data_filename, settings["hostfilename"])
  File "updateHostsFile.py", line 590, in update_all_sources
    update_data = json.load(update_file)
  File "C:\Program Files\Python37\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp932' codec can't decode byte 0x93 in position 29: illegal multibyte sequence
        1 file(s) copied.
```

I guess this happens since I am using CJKV language options in Windows and Python follows it.

My fix to the issue is specifying encoding to UTF-8. Please see if the 'fix' is acceptable or not.