### PR TITLE
IP Logger and URL Shortener Tracking Services

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -968,11 +968,41 @@
 0.0.0.0 hbbtv.mediaset.net
 
 # See Issue #844 – Windows telemetry servers – https://github.com/StevenBlack/hosts/issues/844
-alpha.telemetry.microsft.com
-eu.vortex-win.data.microsft.com
-oca.telemetry.microsft.com
-us.vortex-win.data.microsft.com
-v10-win.vortex.data.microsft.com.akadns.net
-v10.vortex-win.data.microsft.com
+0.0.0.0 alpha.telemetry.microsft.com
+0.0.0.0 eu.vortex-win.data.microsft.com
+0.0.0.0 oca.telemetry.microsft.com
+0.0.0.0 us.vortex-win.data.microsft.com
+0.0.0.0 v10-win.vortex.data.microsft.com.akadns.net
+0.0.0.0 v10.vortex-win.data.microsft.com
+
+# Grabify IP Logger
+
+0.0.0.0 grabify.link
+0.0.0.0 bmwforum.co
+0.0.0.0 leancoding.co
+0.0.0.0 spottyfly.com
+0.0.0.0 stopify.co
+0.0.0.0 yoütu.be
+0.0.0.0 discörd.com
+0.0.0.0 särahah.eu
+0.0.0.0 minecräft.com
+0.0.0.0 freegiftcards.co
+0.0.0.0 disçordapp.com
+0.0.0.0 särahah.pl
+0.0.0.0 xda-developers.us
+0.0.0.0 quickmessage.us
+0.0.0.0 fortnight.space
+0.0.0.0 fortnitechat.site
+0.0.0.0 youshouldclick.us
+0.0.0.0 joinmy.site
+0.0.0.0 watches-my.stream
+
+# IP Logger
+
+0.0.0.0 iplogger.org
+0.0.0.0 2no.co
+0.0.0.0 iplogger.com
+0.0.0.0 iplogger.ru
+0.0.0.0 yip.su
 
 #=====================================


### PR DESCRIPTION
Added domains associated with Grabify IP Logger (https://grabify.link/) and IP Logger URL Shortener (https://iplogger.org/)

These are just the first two services of their kind that pop up in Google search and none of their domains are currently being blocked, except for iplogger.org from someonewhocares.org. Neither require any kind of log-in or account and can both be used completely anonymously. If anyone has time to search around for more of these, please contribute what you can. There are many more such services out there, both with and without log-in/account requirements, and we should work to close this gap as soon as possible.