### PR TITLE
Malware hosts using ttwitter.com not twitter.com

### DIFF
--- a/hosts
+++ b/hosts
@@ -3444,7 +3444,7 @@ ff02::3 ip6-allhosts
 0.0.0.0 proxy.or4.marketscore.com
 0.0.0.0 proxy.sj3.marketscore.com
 0.0.0.0 proxy.sj4.marketscore.com
-0.0.0.0 p.twitter.com
+0.0.0.0 p.ttwitter.com
 0.0.0.0 qbittorrent.com
 0.0.0.0 quantcast584928381.s.moatpixel.com
 0.0.0.0 quantserve.com  #: Ad Tracking, JavaScript, etc.
@@ -3524,7 +3524,7 @@ ff02::3 ip6-allhosts
 0.0.0.0 s.clickability.com
 0.0.0.0 sclk.org
 0.0.0.0 scorecardresearch.com
-0.0.0.0 scribe.twitter.com
+0.0.0.0 scribe.ttwitter.com
 0.0.0.0 scrooge.channelcincinnati.com
 0.0.0.0 scrooge.channeloklahoma.com
 0.0.0.0 scrooge.click10.com


### PR DESCRIPTION
Not sure which is the right source to fix this so updating hosts.