### PR TITLE
Add misspelling of amazon.co.uk

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -966,6 +966,9 @@
 0.0.0.0 ads.samsungads.com
 0.0.0.0 enabler.datalake.mediaset.it
 0.0.0.0 hbbtv.mediaset.net
+0.0.0.0 amazonco.uk # misspelling
+0.0.0.0 www.myishop.co.uk
+0.0.0.0 www2.myishop.co.uk
 
 # See Issue #844 – Windows telemetry servers – https://github.com/StevenBlack/hosts/issues/844
 0.0.0.0 alpha.telemetry.microsft.com


### PR DESCRIPTION
Adds a potential misspelling of amazon.co.uk and some ad pages it redirects to.