### PR TITLE
Update hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -23,7 +23,7 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
-0.0.0.0 0.0.0.0
+0.0.0.0 Blocked_in_hosts_file
 
 # Custom host records are listed here.
 

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -954,7 +954,7 @@ def write_opening_header(final_file, **header_params):
         write_data(final_file, "ff02::1 ip6-allnodes\n")
         write_data(final_file, "ff02::2 ip6-allrouters\n")
         write_data(final_file, "ff02::3 ip6-allhosts\n")
-        write_data(final_file, "0.0.0.0 0.0.0.0\n")
+        write_data(final_file, "0.0.0.0 blocked_in_hosts_file\n")
 
         if platform.system() == "Linux":
             write_data(final_file, "127.0.1.1 " + socket.gethostname() + "\n")


### PR DESCRIPTION
Changed Line 26's title from 0.0.0.0 to "blocked in hosts file" so novice users using a network monitoring tool such as proccess hacker will see "blocked in hosts file" for applications that traffic is set to 0.0.0.0 rather than seeing "0.0.0.0" and wondering why some applications are reporting that IP rather than localhost