### PR TITLE
Updated Ubuntu/Debian Flush DNS Command to Use Systemd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -330,7 +330,7 @@ sc stop "Dnscache"
 
 Open a Terminal and run with root privileges:
 
-**Debian/Ubuntu** `sudo service network-manager restart`
+**Debian/Ubuntu** `sudo systemctl restart NetworkManager.service`
 
 **Linux Mint** `sudo /etc/init.d/dns-clean start`
 


### PR DESCRIPTION
The command now uses systemctl instead of service.