### PR TITLE
Remove kiwifarms.net

### DIFF
--- a/data/CoinBlockerList/hosts
+++ b/data/CoinBlockerList/hosts
@@ -803,7 +803,6 @@
 0.0.0.0 kippbeak.cf
 0.0.0.0 kissdoujin.com
 0.0.0.0 kisshentai.net
-0.0.0.0 kiwifarms.net
 0.0.0.0 kjli.fi
 0.0.0.0 krb.devphp.org.ua
 0.0.0.0 ksimdw.ru
@@ -2772,7 +2771,6 @@
 0.0.0.0 www.kinohabr.net
 0.0.0.0 www.kippbeak.cf
 0.0.0.0 www.kisshentai.net
-0.0.0.0 www.kiwifarms.net
 0.0.0.0 www.krb.devphp.org.ua
 0.0.0.0 www.ksimdw.ru
 0.0.0.0 www.kunay.nullrefexcep.com


### PR DESCRIPTION
It already has been removed once https://github.com/StevenBlack/hosts/pull/443 but apparently was pulled in again while the site is stil miner-free.