### PR TITLE
Added Viber app ad addresses

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1215,3 +1215,7 @@
 0.0.0.0 powerad.ai
 0.0.0.0 hb.brainlyads.com
 0.0.0.0 report.hb.brainlyads.com
+
+# Viber App Ads
+0.0.0.0 s-bid.rmp.rakuten.com
+0.0.0.0 s-imp.rmp.rakuten.com


### PR DESCRIPTION
These 2 addresses are not included in the 'Unified hosts' file. 

There are 4 more (6 in total) which are already included:
0.0.0.0 ads.viber.com
0.0.0.0 ads.aws.viber.com
0.0.0.0 ads-d.viber.com
0.0.0.0 api.mixpanel.com

Tested and working on Windows.
[From the source, apparently it also works on Mac.](https://superuser.com/questions/1477874/remove-ads-in-viber-for-pc)