### PR TITLE
Update Readme to point Catalina users to the location of hosts file

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -234,7 +234,9 @@ We tried that.  Using `0` doesn't work universally.
 To modify your current `hosts` file, look for it in the following places and modify it with a text
 editor.
 
-**Mac OS X, iOS, Android, Linux**: `/etc/hosts` file.
+**mac OS (until 10.14.x macOS Mojave), iOS, Android, Linux**: `/etc/hosts` file.
+
+**macOS Catalina:** `/private/etc/hosts` file.
 
 **Windows**: `%SystemRoot%\system32\drivers\etc\hosts` file.
 


### PR DESCRIPTION
Catalina mounts the OS volume on a readonly partition and the default `/etc/hosts` is not editable.
To circumvent this one should be using the `/private/etc/hosts` file