### PR TITLE
change Badd-Boyz-Hosts LICENSE to MIT

### DIFF
--- a/data/Badd-Boyz-Hosts/update.json
+++ b/data/Badd-Boyz-Hosts/update.json
@@ -5,5 +5,5 @@
     "frequency": "weekly",
     "issues": "https://github.com/mitchellkrogza/Badd-Boyz-Hosts/issues",
     "url": "https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts",
-    "license": "'non-commercial with attribution'"
+    "license": "MIT"
 }


### PR DESCRIPTION
In reviewing these LICENSEs,  upstream for this provider appears to be MIT?
https://github.com/mitchellkrogza/Badd-Boyz-Hosts/blob/fec2f7907f892fde970a11c31ad145e622b96c86/LICENSE.md

I might be mistaken.