### PR TITLE
hostfiles.org is LGPL, not GPL

### DIFF
--- a/data/add.2o7Net/update.json
+++ b/data/add.2o7Net/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.2o7Net/hosts",
-    "license": "GPLv3+"
+    "license": "LGPL-3.0+"
 }

--- a/data/add.Dead/update.json
+++ b/data/add.Dead/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Dead/hosts",
-    "license": "GPLv3+"
+    "license": "LGPL-3.0+"
 }

--- a/data/add.Risk/update.json
+++ b/data/add.Risk/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts",
-    "license": "GPLv3+"
+    "license": "LGPL-3.0+"
 }

--- a/data/add.Spam/update.json
+++ b/data/add.Spam/update.json
@@ -5,5 +5,5 @@
     "frequency": "occasionally",
     "issues": "https://github.com/FadeMind/hosts.extras/issues",
     "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts",
-    "license": "GPLv3+"
+    "license": "LGPL-3.0+"
 }


### PR DESCRIPTION
@FadeMind this is mentioned as `GPLv3+` in your repository too.

From the `BadHosts Blocking Hosts File (Unix) 20-April-2018` (from http://www.hostsfile.org/)

> Licensed under the LGPL a copy of the license may be viewed at http://www.gnu.org/licenses/lgpl.txt

I _think_ it might actually be `LGPL-2.0+`,  from a quote in 1 of the included files:
> It is licensed under the LGPL as GPLv2

But,  that isn't 100% obvious if it applies to all files included in that archive.

I am not a lawyer,  but,  I don't think what is there currently matches what is nominated by `hostsfile.org`;  this is my attempt to rectify that.