### PR TITLE
Add analytics domain for Jodel

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1234,3 +1234,6 @@
 0.0.0.0 cdn.castoola.com
 0.0.0.0 castoola.com
 0.0.0.0 castoola.tv.lan
+
+# Jodel APP 
+0.0.0.0 analytics.ext.go-tellm.com


### PR DESCRIPTION
This domain is used by Jodel to track analytics

App: https://play.google.com/store/apps/details?id=com.tellm.android.app&hl=en