### PR TITLE
Stop bypassing IPv4 network hosts entry by applovin.com due IPv6 network

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -188,6 +188,7 @@
 0.0.0.0 logitechlogitechglobal.112.2o7.net
 0.0.0.0 www.logitechlogitechglobal.112.2o7.net
 0.0.0.0 ma1310-r.analytics.edgekey.net
+0.0.0.0 ipv6-wildcard.applovin.com.edgekey.net
 0.0.0.0 ovc2-ustokyyneikyfasnm.stackpathdns.com
 0.0.0.0 securemetrics.apple.com
 0.0.0.0 smetrics.bestbuy.com


### PR DESCRIPTION
This entry stop ads from applovin in the the FDDB Extender App