### PR TITLE
Enable safesearch

### DIFF
--- a/extensions/porn/MyPrivacyDNS/update.json
+++ b/extensions/porn/MyPrivacyDNS/update.json
@@ -1,0 +1,9 @@
+{
+    "name": "Safe Search by My Privacy DNS",
+    "description": "This is a user contributed hosts list to enabling safe search by default in browsers. For some sites it will even lock the browser in safe search mode. Ex. duckduckgo.com and you have to clean your cookie for ddg to enable normal search",
+    "homeurl": "https://gitlab.com/my-privacy-dns/matrix/matrix",
+    "frequency": "weekly",
+    "issues": "https://gitlab.com/my-privacy-dns/matrix/matrix/issues",
+    "url": "https://gitlab.com/my-privacy-dns/matrix/matrix/raw/master/safesearch/safesearch.hosts",
+    "license": "GNU Affero General Public License v3.0"
+}


### PR DESCRIPTION
This contribution is to enable safe search in browsers by default, by redirecting to safe urls by ip.

Ex. 

safe.duckduckgo.com have ips: 79.125.106.1, 54.229.105.151, 79.125.105.136.
so by adding this to the hosts
```
# DuckDuckGo.com The only real safe serach engine
79.125.106.1 duckduckgo.com
54.229.105.151 duckduckgo.com
79.125.105.136 duckduckgo.com
```

you will redirect all duckduckgo.com to safe.duckduckgo.com but keeping the duckduckgo.com in the address bar