### PR TITLE
Added "faymobi.com" and "a.faymobi.com"

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1224,3 +1224,7 @@
 0.0.0.0 www.hostingfreelife.com
 0.0.0.0 hostingfreelife.com
 0.0.0.0 d3dkhq0wwdwodv.cloudfront.net
+
+# Mobile App Malware
+0.0.0.0 faymobi.com
+0.0.0.0 a.faymobi.com


### PR DESCRIPTION
As per this article:
https://www.evina.fr/a-malware-rises-to-the-top-applications-in-google-play-store/

I checked Google Play:
https://webcache.googleusercontent.com/search?q=cache:ifwcm9AbwzgJ:https://play.google.com/store/apps/details%3Fid%3Dcom.sstars.walls

That's a cached page from Google since the actual page was already taken down. The information on that page confirms some of the numbers from the article. And when you search it in search engines, there's a lot of hype about it being in "top" lists, so this threat report seems legit. There's not much other news on this particular threat though because the time frame was so quick, but it's very possible this domain could be used again for similar attacks, or even is being actively used by other apps not yet caught.