### PR TITLE
Added www.fsisiw3i.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1172,3 +1172,4 @@
 0.0.0.0 mackeeperapp.zeobit.com
 0.0.0.0 www.mackeeperapp.zeobit.com
 0.0.0.0 in8.zog.link
+0.0.0.0 www.fsisiw3i.com


### PR DESCRIPTION
I came across the domain www.fsisiw3i.com which is only reachable over https and currently displays this:

```
eimquydhlptxcgkoswbfjnrvaeimquydhlptxcgkoswbfjnrvaeimquydhlptxc

slewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjcungyrkdvohaslewpibtmfxqjc
```

Pretty sketchy.