### PR TITLE
adds try catch and a avoid OSX conflict errors

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -22,7 +22,14 @@ import time
 from glob import glob
 
 import lxml  # noqa: F401
-from bs4 import BeautifulSoup
+
+# https://github.com/StevenBlack/hosts/issues/590 ModuleNotFoundError for OSX
+# sys.path.append('/usr/local/lib/python3.7/site-packages')
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    from BeautifulSoup import BeautifulSoup
 
 # Detecting Python 3 for version-dependent implementations
 PY3 = sys.version_info >= (3, 0)


### PR DESCRIPTION
```python
# https://github.com/StevenBlack/hosts/issues/590 ModuleNotFoundError for OSX
# sys.path.append('/usr/local/lib/python3.7/site-packages')

try:
    from bs4 import BeautifulSoup
except ImportError:
    from BeautifulSoup import BeautifulSoup

```

Add a in-code correction for site-packages calls for bs4/BeautifulSoup

`sys.path.append` is needed in operating systems running multiple versions of python (I think).

In OSX you'll notice that when you run `$ python -m site --user-site` you can get the user specific site-packages location and append that to the script to correct the issue. Left commented out so that it is only applied by those that need it. Wasn't sure if it should be enabled by default.

Also wrapped the import in a try/catch. This is usually good practice and helps improve the error output. Admittedly this doesn't add a lot of value for this error but it did help me a bit at diagnosing the issue. 
### Before
![Screen Shot 2020-02-04 at 8 16 32 AM](https://user-images.githubusercontent.com/2738244/73748103-c7860580-4726-11ea-9989-030d7e0d895f.png)
### After
![Screen Shot 2020-02-04 at 8 16 51 AM](https://user-images.githubusercontent.com/2738244/73748150-da98d580-4726-11ea-8785-712bb6d7f7b2.png)

Welcome to close this if you don't feel like this adds value to the repo.