### PR TITLE
Travis CI: remove the deprecated `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ notifications:
 
 language: generic
 
-sudo: false
-
 cache:
   directories:
     - $HOME/miniconda3


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration