### PR TITLE
package.json: add `private: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.57",
   "description": "Extending and consolidating hosts files from several well-curated sources like adaway.org, mvps.org, malwaredomainlist.com, someonewhocares.org, and potentially others. You can optionally invoke extensions to block additional sites by category.",
   "main": "",
+  "private": true,
   "scripts": {
     "test": "python3 testUpdateHostsFile.py",
     "start": "python3 makeHosts.py",


### PR DESCRIPTION
The package isn't published on npm.

I haven't tested this with release-it, but it's common practice to have this set to if the package isn't published.