### PR TITLE
updateHostsWindows.bat: minor consistency changes

### DIFF
--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -1,61 +1,61 @@
 ::
-:: This script will first create a backup of the original or current hosts
-:: file and save it in a file titled "hosts.skel"
+:: This script will first create a backup of the original or the current hosts
+:: file and save it in a file named "hosts.skel".
 ::
-:: If "hosts.skel" exists, the new hosts file with the customized unified hosts
-:: will be copied to the proper path. Next, the DNS cache will be refreshed.
+:: If the "hosts.skel" file exists, the new hosts file with the customized unified
+:: hosts will be copied to the proper path. Next, the DNS cache will be refreshed.
 ::
 :: THIS BAT FILE MUST BE LAUNCHED WITH ADMINISTRATOR PRIVILEGES
 :: Admin privileges script based on https://stackoverflow.com/a/10052222
 ::
-::
-@ECHO OFF
-TITLE Update Hosts
 
-:: Check if we are administrator. If not, exit immediately.
+@echo off
+title Update Hosts
+
+:: Check if we are an administrator. If not, exit immediately.
 :: BatchGotAdmin
-:-------------------------------------
-REM  --> Check for permissions
-    IF "%PROCESSOR_ARCHITECTURE%" EQU "amd64" (
->nul 2>&1 "%SYSTEMROOT%\SysWOW64\cacls.exe" "%SYSTEMROOT%\SysWOW64\config\system"
-) ELSE (
->nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+:: Check for permissions
+if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
+    >nul 2>&1 "%SYSTEMROOT%\SysWOW64\cacls.exe" "%SYSTEMROOT%\SysWOW64\config\system"
+) else (
+    >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 )
 
-REM --> If error flag set, we do not have admin.
-if '%errorlevel%' NEQ '0' (
+:: If the error flag set, we do not have admin rights.
+if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
     goto UACPrompt
-) else ( goto gotAdmin )
+) else (
+    goto gotAdmin
+)
 
 :UACPrompt
-    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
-    set params= %*
-    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%temp%\getadmin.vbs"
+echo Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
+set params= %*
+echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
 
-    "%temp%\getadmin.vbs"
-    del "%temp%\getadmin.vbs"
-    exit /B
+wscript.exe "%TEMP%\getadmin.vbs"
+del "%TEMP%\getadmin.vbs"
+exit /b
 
 :gotAdmin
-    pushd "%CD%"
-    CD /D "%~dp0"
+cd /d "%~dp0"
 
 :BackupHosts
-	:: Backup default hosts file
-	if not exist "%WINDIR%\System32\drivers\etc\hosts.skel" (
-		COPY %WINDIR%\System32\drivers\etc\hosts %WINDIR%\System32\drivers\etc\hosts.skel
-	)
+:: Backup the default hosts file
+if not exist "%WINDIR%\System32\drivers\etc\hosts.skel" (
+    copy /v "%WINDIR%\System32\drivers\etc\hosts" "%WINDIR%\System32\drivers\etc\hosts.skel"
+)
 
 :UpdateHosts
-	:: Update hosts file
-	python updateHostsFile.py --auto --minimise
-	
-	:: Move new hosts file in-place
-	COPY hosts %WINDIR%\System32\drivers\etc\
+:: Update hosts file
+python updateHostsFile.py --auto --minimise
 
-	:: Flush the DNS cache
-	ipconfig /flushdns
-	
-	:: Summary note
-	pause
+:: Copy over the new hosts file in-place
+copy /y /v hosts "%WINDIR%\System32\drivers\etc\"
+
+:: Flush the DNS cache
+ipconfig /flushdns
+
+:: Summary note
+pause


### PR DESCRIPTION
* fix a few typos
* fix indentation
* lowercase commands since on Windows case doesn't matter
* add `/y /v` flags in copy commands
* remove unneeded `pushd` command since we `cd` after that anyway
* add `wscript.exe` when calling the .vbs script

Non-whitespace diff: <https://github.com/StevenBlack/hosts/pull/1162/files?w=1>