### PR TITLE
Fix link issue under Windows.

### DIFF
--- a/updateReadme.py
+++ b/updateReadme.py
@@ -45,6 +45,9 @@ def main():
                 "Unified hosts **+ " + key.replace("-", " + ") + "**"
             )
 
+        if "\\" in data[key]["location"]:
+            data[key]["location"] = data[key]["location"].replace("\\", "/")
+
         toc_rows += s.substitute(data[key]) + "\n"
 
     row_defaults = {


### PR DESCRIPTION
We never saw this, as we are not Windows user ourselves but there is
a real issue.

Indeed, as mentionned by @XhmikosR at
https://github.com/StevenBlack/hosts/pull/1163#issuecomment-590057635
the web links are not correctly formated. Indeed, as we use `sep` to
detect the right directory separator, it's also written into the
`readmeData.json` file.

This patch simply, replace the `\` of Windows, with the universal `/` of
the web convention.