### PR TITLE
Ensure that the readme is written in UTF-8.

### DIFF
--- a/updateReadme.py
+++ b/updateReadme.py
@@ -79,7 +79,9 @@ def main():
             this_row.update(source)
             source_rows += t.substitute(this_row) + "\n"
 
-        with open(os.path.join(data[key]["location"], README_FILENAME), "wt") as out:
+        with open(
+            os.path.join(data[key]["location"], README_FILENAME), "wt", encoding="utf-8"
+        ) as out:
             for line in open(README_TEMPLATE):
                 line = line.replace(
                     "@GEN_DATE@", time.strftime("%B %d %Y", time.gmtime())


### PR DESCRIPTION
This patch fixes #1166.

Indeed as stated in the documentation:

> In text mode, if encoding is not specified the encoding used is platform
> dependent: locale.getpreferredencoding(False) is called to get the
> current locale encoding.

That may explain the issue mentionned in #1166.

Docs link:
  * https://docs.python.org/3/library/functions.html#open