### PR TITLE
Keep checkout unmodified when adding outputpath.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,11 +163,6 @@ in a subfolder.  If the subfolder does not exist, it will be created.
 section at the top, containing lines like `127.0.0.1 localhost`.  This is
 useful for configuring proximate DNS services on the local network.
 
-`--nogendata`, or `-g`: `false` (default) or `true`, skip the generation of the
-readmeData.json file used for generating readme.md files.  This is useful if you are
-generating host files with additional whitelists or blacklists and want to keep your
-local checkout of this repo unmodified.
-
 `--compress`, or `-c`: `false` (default) or `true`, *Compress* the hosts file
 ignoring non-necessary lines (empty lines and comments) and putting multiple
 domains in each line. Reducing the number of lines of the hosts file improves

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,11 @@ in a subfolder.  If the subfolder does not exist, it will be created.
 section at the top, containing lines like `127.0.0.1 localhost`.  This is
 useful for configuring proximate DNS services on the local network.
 
+`--nogendata`, or `-g`: `false` (default) or `true`, skip the generation of the
+readmeData.json file used for generating readme.md files.  This is useful if you are
+generating host files with additional whitelists or blacklists and want to keep your
+local checkout of this repo unmodified.
+
 `--compress`, or `-c`: `false` (default) or `true`, *Compress* the hosts file
 ignoring non-necessary lines (empty lines and comments) and putting multiple
 domains in each line. Reducing the number of lines of the hosts file improves

--- a/readme_template.md
+++ b/readme_template.md
@@ -131,6 +131,11 @@ in a subfolder.  If the subfolder does not exist, it will be created.
 section at the top, containing lines like `127.0.0.1 localhost`.  This is
 useful for configuring proximate DNS services on the local network.
 
+`--nogendata`, or `-g`: `false` (default) or `true`, skip the generation of the
+readmeData.json file used for generating readme.md files.  This is useful if you are
+generating host files with additional whitelists or blacklists and want to keep your
+local checkout of this repo unmodified.
+
 `--compress`, or `-c`: `false` (default) or `true`, *Compress* the hosts file
 ignoring non-necessary lines (empty lines and comments) and putting multiple
 domains in each line. Reducing the number of lines of the hosts file improves

--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1268,6 +1268,7 @@ class TestFlushDnsCache(BaseStdout):
                 ]:
                     self.assertIn(expected, output)
 
+
 class TestRemoveOldHostsFile(BaseMockDir):
     def setUp(self):
         super(TestRemoveOldHostsFile, self).setUp()

--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1286,16 +1286,14 @@ class TestRemoveOldHostsFile(BaseMockDir):
     def test_remove_hosts_file(self):
         old_dir_count = self.dir_count
 
-        with self.mock_property("updateHostsFile.BASEDIR_PATH"):
-            updateHostsFile.BASEDIR_PATH = self.test_dir
-            remove_old_hosts_file(backup=False)
+        remove_old_hosts_file(self.hosts_file, backup=False)
 
-            new_dir_count = old_dir_count + 1
-            self.assertEqual(self.dir_count, new_dir_count)
+        new_dir_count = old_dir_count + 1
+        self.assertEqual(self.dir_count, new_dir_count)
 
-            with open(self.hosts_file, "r") as f:
-                contents = f.read()
-                self.assertEqual(contents, "")
+        with open(self.hosts_file, "r") as f:
+            contents = f.read()
+            self.assertEqual(contents, "")
 
     def test_remove_hosts_file_exists(self):
         with open(self.hosts_file, "w") as f:
@@ -1303,40 +1301,36 @@ class TestRemoveOldHostsFile(BaseMockDir):
 
         old_dir_count = self.dir_count
 
-        with self.mock_property("updateHostsFile.BASEDIR_PATH"):
-            updateHostsFile.BASEDIR_PATH = self.test_dir
-            remove_old_hosts_file(backup=False)
+        remove_old_hosts_file(self.hosts_file, backup=False)
 
-            new_dir_count = old_dir_count
-            self.assertEqual(self.dir_count, new_dir_count)
+        new_dir_count = old_dir_count
+        self.assertEqual(self.dir_count, new_dir_count)
 
-            with open(self.hosts_file, "r") as f:
-                contents = f.read()
-                self.assertEqual(contents, "")
+        with open(self.hosts_file, "r") as f:
+            contents = f.read()
+            self.assertEqual(contents, "")
 
-    @mock.patch("updateHostsFile.path_join_robust", side_effect=mock_path_join_robust)
+    @mock.patch("time.strftime", return_value="-new")
     def test_remove_hosts_file_backup(self, _):
         with open(self.hosts_file, "w") as f:
             f.write("foo")
 
         old_dir_count = self.dir_count
 
-        with self.mock_property("updateHostsFile.BASEDIR_PATH"):
-            updateHostsFile.BASEDIR_PATH = self.test_dir
-            remove_old_hosts_file(backup=True)
+        remove_old_hosts_file(self.hosts_file, backup=True)
 
-            new_dir_count = old_dir_count + 1
-            self.assertEqual(self.dir_count, new_dir_count)
+        new_dir_count = old_dir_count + 1
+        self.assertEqual(self.dir_count, new_dir_count)
 
-            with open(self.hosts_file, "r") as f:
-                contents = f.read()
-                self.assertEqual(contents, "")
+        with open(self.hosts_file, "r") as f:
+            contents = f.read()
+            self.assertEqual(contents, "")
 
-            new_hosts_file = self.hosts_file + "-new"
+        new_hosts_file = self.hosts_file + "-new"
 
-            with open(new_hosts_file, "r") as f:
-                contents = f.read()
-                self.assertEqual(contents, "foo")
+        with open(new_hosts_file, "r") as f:
+            contents = f.read()
+            self.assertEqual(contents, "foo")
 
 
 # End File Logic

--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1268,16 +1268,6 @@ class TestFlushDnsCache(BaseStdout):
                 ]:
                     self.assertIn(expected, output)
 
-
-def mock_path_join_robust(*args):
-    # We want to hard-code the backup hosts filename
-    # instead of parametrizing based on current time.
-    if len(args) == 2 and args[1].startswith("hosts-"):
-        return os.path.join(args[0], "hosts-new")
-    else:
-        return os.path.join(*args)
-
-
 class TestRemoveOldHostsFile(BaseMockDir):
     def setUp(self):
         super(TestRemoveOldHostsFile, self).setUp()

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -148,12 +148,12 @@ def main():
         help="Skip static localhost entries " "in the final hosts file.",
     )
     parser.add_argument(
-        "--skip-readme-data-update",
-        "-d",
-        dest="skipreadmedataupdate",
-        default=False,
-        action="store_true",
-        help="Skip update of readme data",
+        "--genreadmedata",
+        "-g",
+        dest="genreadmedata",
+        default=True,
+        action="store_false",
+        help="Skip generation of readmeData.json",
     )
     parser.add_argument(
         "--output",
@@ -285,7 +285,7 @@ def main():
     )
     final_file.close()
 
-    if not settings["skipreadmedataupdate"]:
+    if settings["genreadmedata"]:
         update_readme_data(
             settings["readmedatafilename"],
             extensions=extensions,

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -148,11 +148,11 @@ def main():
         help="Skip static localhost entries " "in the final hosts file.",
     )
     parser.add_argument(
-        "--genreadmedata",
+        "--nogendata",
         "-g",
-        dest="genreadmedata",
-        default=True,
-        action="store_false",
+        dest="nogendata",
+        default=False,
+        action="store_true",
         help="Skip generation of readmeData.json",
     )
     parser.add_argument(
@@ -285,7 +285,7 @@ def main():
     )
     final_file.close()
 
-    if settings["genreadmedata"]:
+    if not settings["nogendata"]:
         update_readme_data(
             settings["readmedatafilename"],
             extensions=extensions,

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -148,6 +148,14 @@ def main():
         help="Skip static localhost entries " "in the final hosts file.",
     )
     parser.add_argument(
+        "--skip-readme-data-update",
+        "-d",
+        dest="skipreadmedataupdate",
+        default=False,
+        action="store_true",
+        help="Skip update of readme data",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         dest="outputsubfolder",
@@ -248,7 +256,9 @@ def main():
     )
 
     merge_file = create_initial_file()
-    remove_old_hosts_file(settings["backup"])
+    remove_old_hosts_file(
+      path_join_robust(settings["outputpath"], "hosts"),
+      settings["backup"])
     if settings["compress"]:
         final_file = open(path_join_robust(settings["outputpath"], "hosts"), "w+b")
         compressed_file = tempfile.NamedTemporaryFile()
@@ -275,13 +285,14 @@ def main():
     )
     final_file.close()
 
-    update_readme_data(
-        settings["readmedatafilename"],
-        extensions=extensions,
-        numberofrules=number_of_rules,
-        outputsubfolder=output_subfolder,
-        sourcesdata=sources_data,
-    )
+    if not settings["skipreadmedataupdate"]:
+        update_readme_data(
+            settings["readmedatafilename"],
+            extensions=extensions,
+            numberofrules=number_of_rules,
+            outputsubfolder=output_subfolder,
+            sourcesdata=sources_data,
+        )
 
     print_success(
         "Success! The hosts file has been saved in folder "
@@ -333,6 +344,7 @@ def prompt_for_update(freshen, update_auto):
 
     if not os.path.isfile(hosts_file):
         try:
+            print("HERE HERE")
             open(hosts_file, "w+").close()
         except (IOError, OSError):
             # Starting in Python 3.3, IOError is aliased
@@ -1272,7 +1284,7 @@ def flush_dns_cache():
             print_failure("Unable to determine DNS management tool.")
 
 
-def remove_old_hosts_file(backup):
+def remove_old_hosts_file(old_file_path, backup):
     """
     Remove the old hosts file.
 
@@ -1285,15 +1297,11 @@ def remove_old_hosts_file(backup):
         Whether or not to backup the existing hosts file.
     """
 
-    old_file_path = path_join_robust(BASEDIR_PATH, "hosts")
-
     # Create if already removed, so remove won't raise an error.
     open(old_file_path, "a").close()
 
     if backup:
-        backup_file_path = path_join_robust(
-            BASEDIR_PATH, "hosts-{}".format(time.strftime("%Y-%m-%d-%H-%M-%S"))
-        )
+        backup_file_path = old_file_path + "{}".format(time.strftime("%Y-%m-%d-%H-%M-%S"))
 
         # Make a backup copy, marking the date in which the list was updated
         shutil.copy(old_file_path, backup_file_path)

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -344,7 +344,6 @@ def prompt_for_update(freshen, update_auto):
 
     if not os.path.isfile(hosts_file):
         try:
-            print("HERE HERE")
             open(hosts_file, "w+").close()
         except (IOError, OSError):
             # Starting in Python 3.3, IOError is aliased

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -257,8 +257,8 @@ def main():
 
     merge_file = create_initial_file()
     remove_old_hosts_file(
-      path_join_robust(settings["outputpath"], "hosts"),
-      settings["backup"])
+        path_join_robust(settings["outputpath"], "hosts"), settings["backup"]
+    )
     if settings["compress"]:
         final_file = open(path_join_robust(settings["outputpath"], "hosts"), "w+b")
         compressed_file = tempfile.NamedTemporaryFile()
@@ -1300,7 +1300,9 @@ def remove_old_hosts_file(old_file_path, backup):
     open(old_file_path, "a").close()
 
     if backup:
-        backup_file_path = old_file_path + "{}".format(time.strftime("%Y-%m-%d-%H-%M-%S"))
+        backup_file_path = old_file_path + "{}".format(
+            time.strftime("%Y-%m-%d-%H-%M-%S")
+        )
 
         # Make a backup copy, marking the date in which the list was updated
         shutil.copy(old_file_path, backup_file_path)


### PR DESCRIPTION
I noticed that when generating files to another location using '-o' the repo is changed.  This makes it harder to build files which include say a whitelist and keep the repo up to date without extra commands.
An example is as follows
```
$ git status 
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
$ python3 updateHostsFile.py -a -n -o ../base
==>fe00::0 ip6-localnet<==
==>ff00::0 ip6-mcastprefix<==
==>ff02::2 ip6-allrouters<==
==>ff02::3 ip6-allhosts<==
Success! The hosts file has been saved in folder ../base
It contains 54,460 unique entries.
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   hosts
	modified:   readmeData.json

no changes added to commit (use "git add" and/or "git commit -a")
```
The changes attached fix this in two ways.  First it looks like remove_old_hosts_file function was always assuming the $BASEDIR_PATH/hosts which led to that file always being zeroed out.  I changed it to take the old_file_path as an argument and send in the constructed path using the outputpath.

The second change was to add an argument to turn off updating the readme data.  I'm less certain this is the right way to do this one, but it doesn't seem to hurt to have an extra option.  Using these I am able to run the command above with an extra '-d' argument and the checkout remains unmodified.