### PR TITLE
Bug fix, plus whitelist/blacklist from command line

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -146,6 +146,13 @@ each domain on a separate line. This is necessary because many implementations
 of URL blockers that rely on `hosts` files do not conform to the standard which
 allows multiple hosts on a single line.
 
+`--blacklist <blacklistfile>`, or `-x <blacklistfile>`: Append the given blacklist file
+in hosts format to the generated hosts file.
+
+`--whitelist <whitelistfile>`, or `-w <whitelistfile>`: Use the given whitelist file
+to remove hosts from the generated hosts file.
+
+
 ## How do I control which sources are unified?
 
 Add one or more *additional* sources, each in a subfolder of the `data/`

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -201,6 +201,20 @@ def main():
         "ignoring non-necessary lines "
         "(empty lines and comments).",
     )
+    parser.add_argument(
+        "--whitelist",
+        "-w",
+        dest="whitelistfile",
+        default="",
+        help="Whitelist file to use while generating hosts files.",
+    )
+    parser.add_argument(
+        "--blacklist",
+        "-x",
+        dest="blacklistfile",
+        default="",
+        help="Blacklist file to use while generating hosts files.",
+    )
 
     global settings
 
@@ -1296,21 +1310,21 @@ def remove_old_hosts_file(old_file_path, backup):
         Whether or not to backup the existing hosts file.
     """
 
-    # Create if already removed, so remove won't raise an error.
-    open(old_file_path, "a").close()
+    # only go through possible backup and removal if the file exists
+    if os.path.isfile(old_file_path):
 
-    if backup:
-        backup_file_path = old_file_path + "{}".format(
-            time.strftime("%Y-%m-%d-%H-%M-%S")
-        )
+        if backup:
+            backup_file_path = old_file_path + "{}".format(
+                time.strftime("%Y-%m-%d-%H-%M-%S")
+            )
 
-        # Make a backup copy, marking the date in which the list was updated
-        shutil.copy(old_file_path, backup_file_path)
+            # Make a backup copy, marking the date in which the list was updated
+            shutil.copy(old_file_path, backup_file_path)
 
-    os.remove(old_file_path)
+        os.remove(old_file_path)
 
     # Create new empty hosts file
-    open(old_file_path, "a").close()
+    open(old_file_path, "wb").close()
 
 
 # End File Logic


### PR DESCRIPTION
Adding two things because they are small.

1. adds blacklist and whitelist file command line overrides
2. fix for my previous pull-request, where attempting to generate with a non-existent output directory resulted in an exception.  This appears to have been because of the open with "a" which does not appear to work with a non-existent directory.  In this case I just use os.path.isfile/1 as os.path already appears to be used in other areas of the script, to skip the initial attempt at creation, then use "wb" on the known non-existent file as that appears to create the directory.

I can split into two PR's if having these two in a single one is a problem, but they are both so small I figured it's probably okay.  Let me know if it's not.