### PR TITLE
Fix default whitelist argument.

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -205,7 +205,7 @@ def main():
         "--whitelist",
         "-w",
         dest="whitelistfile",
-        default=path_join_robust(BASEDIR_PATH, "blacklist"),
+        default=path_join_robust(BASEDIR_PATH, "whitelist"),
         help="Whitelist file to use while generating hosts files.",
     )
     parser.add_argument(


### PR DESCRIPTION
Recent changes in #1227 allowed setting the whitelist and blacklist files via command line arguments. That change set the wrong default for the `--whitelist` option.

This PR changes the default whitelist file from 'blacklist' to 'whitelist'.
