### PR TITLE
Restore filename to follow the hosts-%Y-%m-%d-%H-%M-%S format

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1376,7 +1376,7 @@ class TestRemoveOldHostsFile(BaseMockDir):
             contents = f.read()
             self.assertEqual(contents, "")
 
-    @mock.patch("time.strftime", return_value="-new")
+    @mock.patch("time.strftime", return_value="new")
     def test_remove_hosts_file_backup(self, _):
         with open(self.hosts_file, "w") as f:
             f.write("foo")

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1345,7 +1345,7 @@ def remove_old_hosts_file(old_file_path, backup):
     open(old_file_path, "a").close()
 
     if backup:
-        backup_file_path = old_file_path + "{}".format(
+        backup_file_path = old_file_path + "-{}".format(
             time.strftime("%Y-%m-%d-%H-%M-%S")
         )
 


### PR DESCRIPTION
On 2d696a42d98212310b80f6085172bd6d67eea7ea the '-' separating hosts from timestamp in backup filename was removed. This pull request is to restore the separator.