### PR TITLE
Remove *.rollbar.com from blacklist

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1084,9 +1084,6 @@
 0.0.0.0 www.sebder.roboinside.me
 0.0.0.0 www.roboinside.me
 0.0.0.0 robux.dev
-0.0.0.0 rollbar.com
-0.0.0.0 api.rollbar.com
-0.0.0.0 www.rollbar.com
 0.0.0.0 rstmir.com
 0.0.0.0 bidder.rtk.io
 0.0.0.0 bucket.rtk.io

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -1084,6 +1084,7 @@
 0.0.0.0 www.sebder.roboinside.me
 0.0.0.0 www.roboinside.me
 0.0.0.0 robux.dev
+0.0.0.0 api.rollbar.com
 0.0.0.0 rstmir.com
 0.0.0.0 bidder.rtk.io
 0.0.0.0 bucket.rtk.io


### PR DESCRIPTION
Rollbar.com is a legit developer tool.

This PRs removes `rollbar.com` and `www.rollbar.com` mentions from blacklist.

Fixes #1281.

Re-created from: #1282.