### PR TITLE
Add blasze IP logger links

### DIFF
--- a/hosts
+++ b/hosts
@@ -2799,7 +2799,13 @@ ff02::3 ip6-allhosts
 0.0.0.0 www.govrefund-uk.com
 
 # Added May 26, 2020
-0.0.0.0 seemascakes.com # End StevenBlack
+0.0.0.0 seemascakes.com
+
+# Added Jun 5, 2020
+0.0.0.0 blasze.tk
+0.0.0.0 blasze.com
+
+# End StevenBlack
 
 # Start adaway.org
 


### PR DESCRIPTION
I noticed the `hosts` file blocks `grabify.link` and `iplogger.org`, two IP loggers, but it doesn't block `blasze.tk` or `blasze.com`, which is also an IP logging service. 