### PR TITLE
add link.getmailspring.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2779,3 +2779,6 @@
 
 # Added June 17, 2020
 0.0.0.0 italiapagamen.com
+
+# Added June 24, 2020
+0.0.0.0 link.getmailspring.com


### PR DESCRIPTION
[Mailspring](https://getmailspring.com/) is an email client that lets users add tracking pixels and link redirects to keep tabs on who opens their emails.

Tracking happens through the domain `link.getmailspring.com` which I've added here.