### PR TITLE
sudo provides root privileges

### DIFF
--- a/alternates/fakenews-gambling-porn-social/readme.md
+++ b/alternates/fakenews-gambling-porn-social/readme.md
@@ -381,7 +381,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-gambling-porn/readme.md
+++ b/alternates/fakenews-gambling-porn/readme.md
@@ -379,7 +379,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-gambling-social/readme.md
+++ b/alternates/fakenews-gambling-social/readme.md
@@ -377,7 +377,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-gambling/readme.md
+++ b/alternates/fakenews-gambling/readme.md
@@ -375,7 +375,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-porn-social/readme.md
+++ b/alternates/fakenews-porn-social/readme.md
@@ -380,7 +380,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-porn/readme.md
+++ b/alternates/fakenews-porn/readme.md
@@ -378,7 +378,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews-social/readme.md
+++ b/alternates/fakenews-social/readme.md
@@ -376,7 +376,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/fakenews/readme.md
+++ b/alternates/fakenews/readme.md
@@ -374,7 +374,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/gambling-porn-social/readme.md
+++ b/alternates/gambling-porn-social/readme.md
@@ -380,7 +380,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/gambling-porn/readme.md
+++ b/alternates/gambling-porn/readme.md
@@ -378,7 +378,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/gambling-social/readme.md
+++ b/alternates/gambling-social/readme.md
@@ -376,7 +376,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/gambling/readme.md
+++ b/alternates/gambling/readme.md
@@ -374,7 +374,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/porn-social/readme.md
+++ b/alternates/porn-social/readme.md
@@ -379,7 +379,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/porn/readme.md
+++ b/alternates/porn/readme.md
@@ -377,7 +377,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/alternates/social/readme.md
+++ b/alternates/social/readme.md
@@ -375,7 +375,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/readme.md
+++ b/readme.md
@@ -373,7 +373,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 

--- a/readme_template.md
+++ b/readme_template.md
@@ -340,7 +340,7 @@ sc stop "Dnscache"
 
 ### Linux
 
-Open a Terminal and run with root privileges:
+Open a Terminal and run:
 
 **Debian/Ubuntu** `sudo service network-manager restart`
 


### PR DESCRIPTION
`sudo` without special options provides the user with root privileges so he doesn't need them before running the commands.