### PR TITLE
Adding Microsoft telemetry domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2915,3 +2915,10 @@
 
 # Added August 3, 2020
 0.0.0.0 instui201.info
+
+# Added August 4, 2020
+0.0.0.0 telemetry.remoteapp.windowsazure.com
+0.0.0.0 telemetry.urs.microsoft.com
+0.0.0.0 us.vortex-win.data.microsoft.com
+0.0.0.0 watson.ppe.telemetry.microsoft.com
+


### PR DESCRIPTION
This PR adds some of the telemetry endpoints that Windows 10 [attempts to prevent you from blocking](https://www.bleepingcomputer.com/news/microsoft/windows-10-hosts-file-blocking-telemetry-is-now-flagged-as-a-risk/) via a HOSTS file.