### PR TITLE
CI: add Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
+          - 3.9
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
@StevenBlack does Python have LTS releases? If so, maybe it would make more sense to reduce the CI-tested versions to the LTS ones?