### PR TITLE
add immopreneur.de and subdomains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2844,3 +2844,11 @@
 # Added November 22, 2020
 0.0.0.0 pamsg.online
 0.0.0.0 www.pamsg.online
+
+# Added December 4, 2020
+0.0.0.0 immopreneur.de
+0.0.0.0 lp.immopreneur.de
+0.0.0.0 campus.immopreneur.de
+0.0.0.0 affiliates.immopreneur.de
+0.0.0.0 api.immopreneur.de
+0.0.0.0 www.immopreneur.de


### PR DESCRIPTION
immopreneur.de (probably hacked) is regularly at the top of many search results in google and redirects to scam sites like slowdistanttube3.live