### PR TITLE
Adware domain: resumersvo.fun

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2844,3 +2844,6 @@
 # Added November 22, 2020
 0.0.0.0 pamsg.online
 0.0.0.0 www.pamsg.online
+
+# Added January 19, 2021
+0.0.0.0 resumersvo.fun

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2847,3 +2847,4 @@
 
 # Added January 19, 2021
 0.0.0.0 resumersvo.fun
+0.0.0.0 lismcanalys.fun


### PR DESCRIPTION
Adware domain. Blocked in default by ESET.