### PR TITLE
added akamaitechnologies

### DIFF
--- a/data/add.Risk/hosts
+++ b/data/add.Risk/hosts
@@ -127,6 +127,7 @@
 0.0.0.0 aitligold.tripod.com
 0.0.0.0 aitsngnuu.angelcities.com
 0.0.0.0 ak.imgfarm.com
+0.0.0.0 akamaitechnologies.com
 0.0.0.0 akirkpatrick.com
 0.0.0.0 alaksaair.com
 0.0.0.0 alaskaaair.com
@@ -450,6 +451,7 @@
 0.0.0.0 darseo.popunder.ru
 0.0.0.0 demo.vertexinfo.in
 0.0.0.0 dentairemalin.com
+0.0.0.0 deploy.static.akamaitechnologies.com
 0.0.0.0 desifever.com
 0.0.0.0 digiaquascr.com
 0.0.0.0 dimarsbg.com
@@ -1338,6 +1340,7 @@
 0.0.0.0 slimxxxtubexvq.ddns.name
 0.0.0.0 slimxxxtubeyge.ddns.name
 0.0.0.0 slimxxxtubeyhz.ddns.name
+0.0.0.0 static.akamaitechnologies.com
 0.0.0.0 smartfixer.software-phile.com
 0.0.0.0 smartgiveaway.com
 0.0.0.0 smc.silvercash.com


### PR DESCRIPTION
I got a request from a friend to investigate an issue originating from his virtualbox virtual machine (clean install in debian). it turns out that virtualbox communicates with that server without permission from the user, the connection is being automatically opened and continously kept up. We dont know what the communication stream contains, it could be innocent upgrade watcher, or a spyware that sends every key press. I have added it to my hosts to test it, it does not seem to break anything.