### PR TITLE
Added partners subdomain for camsoda

### DIFF
--- a/hosts
+++ b/hosts
@@ -374,6 +374,7 @@ ff02::3 ip6-allhosts
 0.0.0.0 www.applog.camera360.com
 0.0.0.0 camsoda.com
 0.0.0.0 www.camsoda.com
+0.0.0.0 partners.camsoda.com
 0.0.0.0 camteens.to
 0.0.0.0 candygirls.cc
 0.0.0.0 canuck-method.com


### PR DESCRIPTION
I was using a pi-hole and apparently, your base list has this website in it, which means that pi-hole wouldn't let me visit any of the localized subdomains like en.camsoda.com, even though these subdomains weren't blocked themselves. Which is probably on purpose and not something I care to tackle. I'm not sure if pi-hole imports localized versions in Gravity or if it's being done on the fly.

However, they [this specific website] apparently map all subdomain variations to their main host (except probably the ones they explicitly defined, like "media" and such), so loading myaltsubdomaintoavoidpihole.camsoda.com actually works by both bypassing pi-hole's "reasonable localization" (I don't know how they call that feature) and also using that subdomain for all the site's workings, session etc.

With that being said, to re-block ads on that website with DNS-based filtering, the only domain I found was "partners.camsoda.com", hence this pull request.