### PR TITLE
Add minecraft-hosts tracking domains

### DIFF
--- a/data/minecraft-hosts/update.json
+++ b/data/minecraft-hosts/update.json
@@ -1,0 +1,9 @@
+{
+    "name": "minecraft-hosts",
+    "description": "Minecraft related tracker hosts",
+    "homeurl": "https://github.com/jamiemansfield/minecraft-hosts",
+    "frequency": "occasionally",
+    "issues": "https://github.com/jamiemansfield/minecraft-hosts/issues",
+    "url": "https://raw.githubusercontent.com/jamiemansfield/minecraft-hosts/master/lists/tracking.txt",
+    "license": "CC0-1.0"
+}


### PR DESCRIPTION
Fixes GH-1638.﻿
