### PR TITLE
add disable-dnscache-service-win.cmd

### DIFF
--- a/disable-dnscache-service-win.cmd
+++ b/disable-dnscache-service-win.cmd
@@ -1,0 +1,49 @@
+@ECHO OFF
+:: Check if we are administrator. If not, exit immediately.
+:: BatchGotAdmin
+:-------------------------------------
+REM  --> Check for permissions
+    IF "%PROCESSOR_ARCHITECTURE%" EQU "amd64" (
+>nul 2>&1 "%SYSTEMROOT%\SysWOW64\cacls.exe" "%SYSTEMROOT%\SysWOW64\config\system"
+) ELSE (
+>nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+)
+
+REM --> If error flag set, we do not have admin.
+if '%errorlevel%' NEQ '0' (
+    echo Requesting administrative privileges...
+    goto UACPrompt
+) else ( goto gotAdmin )
+
+:UACPrompt
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+    set params= %*
+    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%temp%\getadmin.vbs"
+
+    "%temp%\getadmin.vbs"
+    del "%temp%\getadmin.vbs"
+    exit /B
+
+:gotAdmin
+    pushd "%CD%"
+    CD /D "%~dp0"
+    goto SCset
+
+:SCset
+:: https://superuser.com/a/1217703
+:: https://stackoverflow.com/a/133926
+::sc config Dnscache start= disabled
+::sc stop Dnscache
+
+:: VALUE 
+:: 2 (Automatic) (DEFAULT)
+:: 4 (Disabled) (prevent freeze network after applying huge hosts file)
+::
+:: Latest changes in security Windows 10 denied access to changing services via other tools except registry hack
+::
+:: See https://superuser.com/a/1277960
+::
+REG add "HKLM\SYSTEM\CurrentControlSet\services\Dnscache" /v Start /t REG_DWORD /d 4 /f
+echo "Reboot your system now!"
+echo .
+@PAUSE

--- a/readme_template.md
+++ b/readme_template.md
@@ -334,6 +334,13 @@ Your operating system will cache DNS lookups. You can either reboot or run the f
 manually flush your DNS cache once the new hosts file is in place.
 
 | The Google Chrome browser may require manually cleaning up its DNS Cache on `chrome://net-internals/#dns` page to thereafter see the changes in your hosts file. See: <https://superuser.com/questions/723703>
+
+## Using huge `hosts` file in Windows required disabling DNS Cache service. You have been warned.
+
+Latest changes in security Windows 10 denied access to changing services via other tools except registry hack. Use file
+`disable-dnscache-service-win.cmd` for made proper changes in registry. After you need to reboot device. 
+Futher see details in cmd file code comment. 
+
 :-----------------------------------------------------------------------------------------
 
 ### Windows


### PR DESCRIPTION
@StevenBlack  

DNSCache service in Windows can **hang** network when you use bigger hosts file. Hard workaround is forcing disable service via registry tweak. Windows 10 have new security and you cannot just using `services.msc` easly. 

Reference:
- https://docs.microsoft.com/en-us/answers/questions/47441/how-to-disable-windows-10-dns-cache-services.html
- https://docs.microsoft.com/en-us/windows-server/networking/dns/troubleshoot/disable-dns-client-side-caching
