### PR TITLE
remove JW Player entries

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -3145,5 +3145,3 @@
 0.0.0.0 track.venatusmedia.com # tracking
 0.0.0.0 amptrack.dailymail.co.uk # tracking
 0.0.0.0 mailmetromedia.amp.permutive.com #ad
-0.0.0.0 videos-cloudflare.jwpsrv.com # video ads
-0.0.0.0 videos-fms.jwpsrv.com # video ads


### PR DESCRIPTION
The JW Player entries below are not used to serve ads, but video content on the JW platform. While it is possible for a video ad creative to be served by the JW platform,  it is not a major use-case of the JW platform  and should not be included in an ad blocker.

0.0.0.0 videos-cloudflare.jwpsrv.com  # video ads
0.0.0.0 videos-fms.jwpsrv.com  # video ads