### PR TITLE
Remove Link Shortener used by State Government Agency

### DIFF
--- a/alternates/fakenews-gambling-porn-social/hosts
+++ b/alternates/fakenews-gambling-porn-social/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/fakenews-gambling-porn/hosts
+++ b/alternates/fakenews-gambling-porn/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/fakenews-gambling-social/hosts
+++ b/alternates/fakenews-gambling-social/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/fakenews-gambling/hosts
+++ b/alternates/fakenews-gambling/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/gambling-porn-social/hosts
+++ b/alternates/gambling-porn-social/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/gambling-porn/hosts
+++ b/alternates/gambling-porn/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/gambling-social/hosts
+++ b/alternates/gambling-social/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io

--- a/alternates/gambling/hosts
+++ b/alternates/gambling/hosts
@@ -86862,7 +86862,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 livelylaugh.com
 0.0.0.0 lizardslaugh.com
 0.0.0.0 lkqd.com
-0.0.0.0 lnks.gd
 0.0.0.0 locked4.com
 0.0.0.0 locpub.com
 0.0.0.0 log.logrocket.io


### PR DESCRIPTION
Lnks.gd is used by the Iowa Department of Public Safety in their press release emails. It is legit and not a gambling site.

[Example](https://lnks.gd/l/eyJhbGciOiJIUzI1NiJ9.eyJidWxsZXRpbl9saW5rX2lkIjoxMDIsInVyaSI6ImJwMjpjbGljayIsImJ1bGxldGluX2lkIjoiMjAyMTA2MTguNDIxNDAwNzEiLCJ1cmwiOiJodHRwczovL2Rwcy5pb3dhLmdvdi90YW1hLWNvdW50eS1zaGVyaWZmcy1vZmZpY2UtYW5kLWRjaS1pbnZlc3RpZ2F0aW5nLXN1c3BpY2lvdXMtZGVhdGg_dXRtX21lZGl1bT1lbWFpbCZ1dG1fc291cmNlPWdvdmRlbGl2ZXJ5In0.i4DowABuKkYG-EY5kKRHE1vxYOitq8RaM3RyD5Be4nI/s/600941620/br/108164725435-l)