### PR TITLE
Update hosts

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2,6 +2,8 @@
 # Title: Hosts contributed by Steven Black
 # http://stevenblack.com
 
+0.0.0.0 wizhumpgyros.com 
+0.0.0.0 coccyxwickimp.com
 0.0.0.0 n2019cov.000webhostapp.com
 0.0.0.0 webmail-who-int.000webhostapp.com
 0.0.0.0 010sec.com


### PR DESCRIPTION
[wizhumpgyros.com](https://github.com/easylist/easylist/blob/b00af2d9a3348d4c389fb5c27411c101405a1da3/easylist/easylist_adservers.txt#L10737)
 
 [coccyxwickimp.com](https://github.com/easylist/easylist/blob/b00af2d9a3348d4c389fb5c27411c101405a1da3/easylist/easylist_adservers.txt#L2321)

Easylists uses the Adblock format and could be [formatted to a hosts file](https://github.com/ProgramComputer/Adblock-hosts-converter) and merged after a diff.

EDIT- I made a [txt file](https://gist.githubusercontent.com/ProgramComputer/4cc3ca99e6aa46c2d4cbf5caaf5d47e9/raw/fdf4a27bb1cb95e562f77aa680dcc9c0a12a2d14/missing.txt) containing adservers in [easylist](https://github.com/easylist/easylist/blob/b00af2d9a3348d4c389fb5c27411c101405a1da3/easylist/easylist_adservers.txt) that is not in [hosts file](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts).

