### PR TITLE
Fix whitelisting issue when RAW list are given

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -543,7 +543,9 @@ class TestGatherCustomExclusions(BaseStdout):
     # Can only test in the invalid domain case
     # because of the settings global variable.
     @mock.patch("updateHostsFile.input", side_effect=["foo", "no"])
-    @mock.patch("updateHostsFile.is_valid_user_provided_domain_format", return_value=False)
+    @mock.patch(
+        "updateHostsFile.is_valid_user_provided_domain_format", return_value=False
+    )
     def test_basic(self, *_):
         gather_custom_exclusions("foo", [])
 
@@ -552,7 +554,9 @@ class TestGatherCustomExclusions(BaseStdout):
         self.assertIn(expected, output)
 
     @mock.patch("updateHostsFile.input", side_effect=["foo", "yes", "bar", "no"])
-    @mock.patch("updateHostsFile.is_valid_user_provided_domain_format", return_value=False)
+    @mock.patch(
+        "updateHostsFile.is_valid_user_provided_domain_format", return_value=False
+    )
     def test_multiple(self, *_):
         gather_custom_exclusions("foo", [])
 

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -944,7 +944,7 @@ def remove_dups_and_excl(merge_file, exclusion_regexes, output_file=None):
             continue
 
         # Issue #1628
-        if ("@" in stripped_rule):
+        if "@" in stripped_rule:
             continue
 
         # Normalize rule

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -955,7 +955,7 @@ def remove_dups_and_excl(merge_file, exclusion_regexes, output_file=None):
         )
 
         for exclude in exclusions:
-            if re.search(r"[\s\.]" + re.escape(exclude) + r"\s", line):
+            if re.search(r"(^|[\s\.])" + re.escape(exclude) + r"\s", line):
                 write_line = False
                 break
 


### PR DESCRIPTION
# Facts

1. I overlooked the whitelisting of RAW / Plain list when I adjusted the code for the support of them.

2. This PR:

    - Fixes #1687.
    - Touches @alagos @dnmTX @avatartw.

# Changes

- `remove_dups_and_excl()` 

Inside the `remove_dups_and_excl()` function, we were matching against such lines:

```
0.0.0.0 example.org
```

and not 

```
example.org
```

This patch fixes the bug by adjusting the regex we use to process the whitelisting. That means that from now on, we are capable of whitelisting from both (hosts + RAW / Plain) formats.

- Blacking. Don't complain or discuss code formatting, just use [Black](http://github.com/psf/black).

