### PR TITLE
Added more gvt2 domains from chrome

### DIFF
--- a/hosts
+++ b/hosts
@@ -7409,6 +7409,10 @@ ff02::3 ip6-allhosts
 0.0.0.0 beacons.gvt2.com
 0.0.0.0 beacons2.gvt2.com
 0.0.0.0 beacons.gcp.gvt2.com
+0.0.0.0 beacons3.gvt2.com
+0.0.0.0 beacons4.gvt2.com
+0.0.0.0 beacons5.gvt2.com
+0.0.0.0 e2clock.gcp.gvt2.com
 
 # [gvt3.com]
 0.0.0.0 beacons5.gvt3.com


### PR DESCRIPTION
While I am using Google Chrome, I noticed some gvt.com domains are not blocked by pi-hole, so I added gvt.com domains that are not in this list. I haven't experienced any sites not working properly with the changes I made. @StevenBlack please review and merge if it is okay to go.