### PR TITLE
Drop Python 3.5 from CI and README.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8

--- a/readme_template.md
+++ b/readme_template.md
@@ -81,7 +81,7 @@ docker run -it (containerid) bash
 
 ### Option 2: Generate it in your own environment
 
-To generate your own amalgamated hosts files you will need Python 3.5 or later.
+To generate your own amalgamated hosts files you will need Python 3.6 or later.
 
 First, install the dependencies with:
 


### PR DESCRIPTION
It's EOL since December 2020.

We could also drop 3.6 since it's going EOL at the end of 2021. If you'd like that, let me know so that I update the PR.