### PR TITLE
A few npm updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ readmeData.json
 hosts-*
 /web.config
 /__pycache__
-/node_modules
+/node_modules/
+/package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "homepage": "https://github.com/StevenBlack/hosts#readme",
   "devDependencies": {
-    "release-it": "^14.11.5"
+    "release-it": "^14.11.6"
   }
 }


### PR DESCRIPTION
@StevenBlack: is `readmeData.json` supposed to be committed? I'm asking because I see it's in .gitignore: https://github.com/StevenBlack/hosts/blob/a3bdc8b71b5577b252e2df018966d084a18a0545/.gitignore#L6

BTW I assume you don't want the package-lock.json file committed hence the second patch. Otherwise let me know and I'll adapt the PR :)