### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1633267966,
+        "narHash": "sha256-gFKvZ5AmV/dDTKXVxacPbXe4R0BsFpwtVaQxuIm2nnk=",
+        "path": "/nix/store/k13ripsl4n2p6wf2ksy5m017ryykx4qc-source",
+        "rev": "7daf35532d2d8bf5e6f7f962e6cd13a66d01a71d",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Unified hosts file with base extensions.";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }: {
+    nixosModule = { config, ... }:
+      with nixpkgs.lib;
+      let
+        cfg = config.networking.stevenBlackHosts;
+        alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
+                         (if cfg.blockGambling then [ "gambling" ] else []) ++
+                         (if cfg.blockPorn then [ "porn" ] else []) ++
+                         (if cfg.blockSocial then [ "social" ] else []);
+        alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
+      in
+      {
+        options.networking.stevenBlackHosts = {
+          enable = mkEnableOption "Use Steven Black's hosts file as extra hosts.";
+          blockFakenews = mkEnableOption "Additionally block fakenews hosts.";
+          blockGambling = mkEnableOption "Additionally block gambling hosts.";
+          blockPorn = mkEnableOption "Additionally block porn hosts.";
+          blockSocial = mkEnableOption "Additionally block social hosts.";
+        };
+        config = mkIf cfg.enable {
+          networking.extraHosts =
+            builtins.readFile (
+              "${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts"
+            );
+        };
+      };
+  } // flake-utils.lib.eachDefaultSystem
+    (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python3
+            python3Packages.flake8
+            python3Packages.requests
+          ];
+        };
+      }
+    );
+}

--- a/readme_template.md
+++ b/readme_template.md
@@ -419,6 +419,8 @@ Then modify the `hosts` line in your `/etc/nsswitch.conf` file to the following:
 hosts: cache files dns
 ```
 
+**NixOS**: The `nscd.service` is automatically restarted when the option `networking.extraHosts` was changed.
+
 **Others**: Consult [this Wikipedia article](https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system).
 
 ### macOS

--- a/readme_template.md
+++ b/readme_template.md
@@ -169,23 +169,6 @@ in hosts format to the generated hosts file.
 `--whitelist <whitelistfile>`, or `-w <whitelistfile>`: Use the given whitelist file
 to remove hosts from the generated hosts file.
 
-#### Using NixOS
-
-To install hosts file on your machine add the following into your `configuration.nix`:
-
-```nix
-{
-  networking.extraHosts = let
-    hostsPath = https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts;
-    hostsFile = builtins.fetchurl hostsPath;
-  in builtins.readFile "${hostsFile}";
-}
-```
-
-* NOTE: Change `hostsPath` if you need other versions of hosts file.
-* NOTE: The call to `fetchurl` is impure.
-Use `fetchFromGitHub` with the exact commit if you want to always get the same result.
-
 ## How do I control which sources are unified?
 
 Add one or more *additional* sources, each in a subfolder of the `data/`
@@ -296,6 +279,58 @@ editor.
 ## Gentoo
 
 Gentoo users may find [`sb-hosts`](https://github.com/PF4Public/gentoo-overlay/tree/master/net-misc/sb-hosts) in [::pf4public](https://github.com/PF4Public/gentoo-overlay) Gentoo overlay
+
+## NixOS
+
+To install hosts file on your machine add the following into your `configuration.nix`:
+
+```nix
+{
+  networking.extraHosts = let
+    hostsPath = https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts;
+    hostsFile = builtins.fetchurl hostsPath;
+  in builtins.readFile "${hostsFile}";
+}
+```
+
+* NOTE: Change `hostsPath` if you need other versions of hosts file.
+* NOTE: The call to `fetchurl` is impure.
+Use `fetchFromGitHub` with the exact commit if you want to always get the same result.
+
+### Nix Flake
+
+NixOS installations which are managed through *flakes* can use the hosts file like this:
+
+```nix
+{
+  inputs.hosts.url = github:StevenBlack/hosts;
+  outputs = { self, nixpkgs, hosts }: {
+    nixosConfigurations.my-hostname = {
+      system = "<architecture>";
+      modules = [
+
+        hosts.nixosModule {
+          networking.stevenBlackHosts.enable = true;
+        }
+
+      ];
+    };
+  };
+}
+```
+
+The hosts extensions are also available with the following options:
+
+```nix
+{
+  networking.stevenBlackHosts = {
+    blockFakenews = true;
+    blockGambling = true;
+    blockPorn = true;
+    blockSocial = true;
+  };
+}
+```
 
 ## Updating hosts file on Windows
 


### PR DESCRIPTION
[Nix Flakes](https://nixos.wiki/wiki/Flakes) are an upcoming feature of the Nix package manager. They allow truly reproducible builds and provide an standardized interface to Nix things like packages, development shells and NixOS modules.

This flake provides a development shell and a NixOS module.
Every user which has a recent version of Nix (and Flakes are enabled) can start a development shell with all requirements fulfilled like this:

```
nix develop
```

NixOS users which use a flaked configuration can use the hosts module in the following way:

```
inputs.hosts.url = github:StevenBlack/hosts;
outputs = { self, nixpkgs, hosts }: {
  ...
  modules = {
    hosts.nixosModule {
      networking.stevenBlackHosts.enable = true;
    }
  };
  ...
};
```

I've also added four options for the host extensions. They can be used like this:

```
networking.stevenBlackHosts = {
  enable = true;
  blockFakenews = true;
  blockGambling = true;
  blockPorn = true;
  blockSocial = true;
};
```

If you like this I can update the README as well :)
