### PR TITLE
Replacement url for clefspeare13/pornhosts

### DIFF
--- a/extensions/porn/clefspeare13/update.json
+++ b/extensions/porn/clefspeare13/update.json
@@ -1,10 +1,10 @@
 {
     "name": "pornhosts -- a consolidated anti porn hosts file",
     "description": "This is an endeavour to find all porn domains and compile them into a single hosts to allow for easy blocking of porn on your local machine or on a network.",
-    "homeurl": "https://github.com/Clefspeare13/pornhosts",
+    "homeurl": "https://mypdns.org/clefspeare13/pornhosts",
     "frequency": "occasional",
-    "issues": "https://github.com/Clefspeare13/pornhosts/issues",
-    "url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/extensions/porn/clefspeare13/hosts",
+    "issues": "https://mypdns.org/my-privacy-dns/porn-records/-/issues",
+    "url": "https://mypdns.org/clefspeare13/pornhosts/-/raw/master/download_here/0.0.0.0/hosts",
     "url.old": "https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/download_here/0.0.0.0/hosts",
     "license": "MIT"
 }


### PR DESCRIPTION
As per Github have taken down yet another Pornhosts list we have moved the active list to a safer location.

The new url, will also remain Actively updated

Related notes:
- https://github.com/easylist/easylist/issues/9207#issuecomment-941989512
- https://github.com/Clefspeare13/pornhosts

![image](https://user-images.githubusercontent.com/91316144/137130955-e15aaa68-6e99-4a97-a524-3087925d6d72.png)
