### PR TITLE
removed a manual indexer iterator pitfall from the code

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1605,8 +1605,8 @@ class DomainToIDNA(Base):
 
         # Test with multiple tabulations as separator of domain and space and
         # tabulation as separator or comments.
-        for i in range(len(self.domains)):
-            data = (b"0.0.0.0\t\t\t" + self.domains[i] + b" \t # Hello World").decode(
+        for i, domain in enumerate(self.domains):
+            data = (b"0.0.0.0\t\t\t" + domain + b" \t # Hello World").decode(
                 "utf-8"
             )
             expected = "0.0.0.0\t\t\t" + self.expected_domains[i] + " \t # Hello World"


### PR DESCRIPTION
**The problem**

The code had a case of the manual indexer iterator pitfall, which happens when one iterates on Python the same way it is done in C. In Python it is advised to perform iterations using the 'enumerate' method as shown [here](https://vald-phoenix.github.io/pylint-errors/plerr/errors/refactoring/C0200.html), thus making the code easier to read an less prone to bugs introduction

**The solution**
Applied the needed refatoring