### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,25 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
+    name: Python ${{ matrix.python }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         python:
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
         os:
           - ubuntu-latest
           - macos-latest
@@ -28,23 +33,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
 
       - run: python --version
       - run: pip --version
-
-      - name: Get pip cache directory
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-python-v${{ matrix.python }}-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-python-v${{ matrix.python }}-${{ hashFiles('**/requirements.txt') }}
-            ${{ runner.os }}-python-v${{ matrix.python }}-
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
* `actions/setup-python` now has built-in support for caching
* add `workflow_dispatch` to add the ability to manually trigger the workflow
* add Python 3.10

I still think we should remove the no longer updated Python 3.5 from CI; now we test 6 Python versions times 3 = 18 builds. Plus there are some warnings on macOS for Python 3.5: https://github.com/StevenBlack/hosts/runs/4498028405?check_suite_focus=true#step:3:1

Alternatively, we could adapt the CI matrix to test on all Python versions only for Ubuntu, and test only 1-2 on the other platforms.

@StevenBlack Either way, let me know and I can make any further changes :)