### PR TITLE
docs: Include link to dnscrypt-proxy blocklist tool

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -488,6 +488,9 @@ devices under a variety of operating systems.
 
 * [BlackHosts - Command Line Installer/Updater](https://github.com/Lateralus138/blackhosts) This is a cross-platform command line utility to help install/update hosts files found at this repository.
 
+* [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Combining-Blocklists) provides a tool to build block lists from local and remote lists in common formats.
+
+
 ## Contribute
 
 Please read our [Contributing Guide](https://github.com/StevenBlack/hosts/blob/master/contributing.md). Among other things, this explains how we organize files and folders in this repository.


### PR DESCRIPTION
Copy-pasted the tool description from the dnscrypt-proxy page.

Fixes: #1830


@StevenBlack @dnmTX PTAL . I think that should suffice, but let me know. Thanks!