### PR TITLE
asecv.xyz

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2186,3 +2186,6 @@
 
 # Added January 2, 2022
 0.0.0.0 mypornsnap.top
+
+# Added January 11, 2022
+0.0.0.0 asecv.xyz


### PR DESCRIPTION
adware domain URL blocked by Smart Screen (Edge) and ESET.

https://whois.domaintools.com/asecv.xyz

![20220111-1641898308](https://user-images.githubusercontent.com/9846948/148929883-a59f2606-7035-47d9-be29-3169ce9c9a35.png)
