### PR TITLE
roksa.sx

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2195,3 +2195,6 @@
 0.0.0.0 technoob.info
 0.0.0.0 thefappeningpics.com
 0.0.0.0 hotzxgirl.com
+
+# Added January 13, 2022
+0.0.0.0 roksa.sx


### PR DESCRIPTION
NRD, probably scam, original domain was shutdown (with .pl sufix). Terms, privacy policy copy paste without owner details from shutdown previously original site.

https://whois.domaintools.com/roksa.sx

Original previously site have notice
```
Działalność portalu ROKSA.pl została zawieszona !

Informujemy, że zaprzestanie działalności portalu jest spowodowane realizacją postanowienia Prokuratury.

Nie mamy nic wspólnego innymi witrynami , podszywającymi się teraz pod naszą markę
```

```
ROKSA.pl has been suspended!

We would like to inform you that the cessation of the portal's activity is caused by the realization of the Prosecutor's decision.

We have nothing in common with other websites that pretend to be our brand

```

SCREENSHOT: [20220113-1642106880](https://user-images.githubusercontent.com/9846948/149406854-c43779d7-0739-49e2-a4ad-e374747fd55e.png)
