### PR TITLE
Please remove Inmoment.com domains as done in Adaway

### DIFF
--- a/data/adaway.org/hosts
+++ b/data/adaway.org/hosts
@@ -5322,11 +5322,6 @@
 127.0.0.1 glance.l.inmobicdn.net
 127.0.0.1 i.l.inmobicdn.net
 
-# [inmoment.com]
-127.0.0.1 dispawsusva.inmoment.com
-127.0.0.1 intercept.inmoment.com
-127.0.0.1 intercept-client.inmoment.com
-
 # [inner-active.mobi]
 127.0.0.1 inner-active.mobi
 127.0.0.1 ad-tag.inner-active.mobi


### PR DESCRIPTION
Please update Adaway org list or merge this request to be consistent with Adaway.  These domains were removed earlier today from the Adaway list.  As you can see by the comments of the contributor who committed the merge, Inmoment.com did not need to be on the list.  

https://github.com/AdAway/adaway.github.io/pull/315/commits/8fac3815d96de082aa39ecab1543a5a37ea8e21c 

InMoment (www.inmoment.com) is a feedback and research company with corporate offices in Salt Lake City, Utah.  We have been mistakenly added to the Adaway list.  We do not serve any ads.  We don't collect any personal information, but we do gather some browser info to help us combat fraud by end users (maybe that is a tripping wire). Some of our programs offer an incentive for providing feedback, like a coupon, free drink, etc which have been abused in the past.  We recently have a number of client and customer complaints that our surveys are not rendering properly and our investigation led us to the addition of our domains on Adaway and your list.   We kindly request we be removed from this list.  Thank you kindly for your hard work and support to privacy.