### PR TITLE
CI: update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
-          cache: pip
 
       - run: python --version
       - run: pip --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - run: python --version
-      - run: pip --version
+      - name: Print versions
+        run: |
+          python --version
+          pip --version
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1


### PR DESCRIPTION
* actions/checkout to v3
* actions/setup-python to v3

@StevenBlack:

1. I still think we should drop Python 3.5, at least from CI since it longer works and make the whole build show as failed :/
2. Shouldn't we run `python3 makeHosts.py` on CI to make sure the scripts work?