### PR TITLE
Use `assertIn` instead of `assertTrue`

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -1765,7 +1765,7 @@ class TestIsValidUserProvidedDomainFormat(BaseStdout):
         output = sys.stdout.getvalue()
         expected = "You didn't enter a domain. Try again."
 
-        self.assertTrue(expected in output)
+        self.assertIn(expected, output)
 
     def test_invalid_domain(self):
         expected = "Do not include www.domain.com or http(s)://domain.com. Try again."


### PR DESCRIPTION
Fixes one of the two issues from https://lgtm.com/projects/g/StevenBlack/hosts/latest/files/testUpdateHostsFile.py?sort=name&dir=ASC&mode=heatmap&showExcluded=true

I'll leave the second on to someone else (if it really needs to be fixed).

I wonder what this line is supposed to do? https://github.com/StevenBlack/hosts/blob/e6da3b0fbfa194e6532247fbbc2b0ebde0fd6dc9/testUpdateHostsFile.py#L57