### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.5'
           - '3.6'
           - '3.7'
           - '3.8'
@@ -33,6 +32,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
 
       - name: Print versions
         run: |
@@ -44,6 +44,9 @@ jobs:
 
       - name: Run lint
         run: flake8
+
+      - name: Run makeHosts.py
+        run: python makeHosts.py
 
       - name: Run tests
         run: python testUpdateHostsFile.py

--- a/readme_template.md
+++ b/readme_template.md
@@ -81,7 +81,7 @@ docker run -it (containerid) bash
 
 ### Option 2: Generate it in your own environment
 
-To generate your own amalgamated hosts files you will need Python 3.5 or later.
+To generate your own amalgamated hosts files you will need Python 3.6 or later.
 
 First, install the dependencies with:
 


### PR DESCRIPTION
* drop Python 3.5
* add pip caching back
* run makeHosts.py

Notes:

- fixes CI errors/warnings:
  <img src="https://user-images.githubusercontent.com/349621/158005967-c4ff9b66-9818-4f0a-b16c-51107da888a2.png" alt="image" width="400">
- reduces CI time approx. to half (**4:30 -> 2:30**)
- I added a `makeHosts.py` run too, we can drop this if you don't like it, but this gives us a chance to automate releases and also test things as close as possible to local
- I'd still drop Python 3.5 support from docs/script itself so that we are consistent and so that we can update deps, see #1920 