### PR TITLE
Removed www2.nixu.com 

### DIFF
--- a/hosts
+++ b/hosts
@@ -42538,7 +42538,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 www2.nielsen.com
 0.0.0.0 www2.nihonzaitaku.co.jp
 0.0.0.0 www2.nilfisk.com
-0.0.0.0 www2.nixu.com
 0.0.0.0 www2.nordcloud.com
 0.0.0.0 www2.novagric.com
 0.0.0.0 www2.nowpensions.com


### PR DESCRIPTION
Nixu and it's webserver www2.nixu.com should not be on the list. Nixu is a cyber security company in Finland.