### PR TITLE
remove clickhouse.com from list

### DIFF
--- a/data/mvps.org/hosts
+++ b/data/mvps.org/hosts
@@ -266,7 +266,6 @@
 0.0.0.0 www.clickvalidator.net
 0.0.0.0 www.is1.clixgalore.com
 0.0.0.0 www.clixgalore.com
-0.0.0.0 www.clickhouse.com
 0.0.0.0 banners.clips4sale.com
 0.0.0.0 www.cnstats.com
 0.0.0.0 www.co2stats.com


### PR DESCRIPTION
The domain clickhouse.com is associated with the Clickhouse Database: https://en.wikipedia.org/wiki/ClickHouse
This website contains documentation etc. and i had to add it to my explicit whitelist.

https://clickhouse.com/docs/en/intro

I think this should be removed.