### PR TITLE
new scam NSFW domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2223,3 +2223,8 @@
 
 # added June 25, 2022
 0.0.0.0 analytics.binaryfortress.com
+
+# added July 10, 2022
+0.0.0.0 seductivegirls.cyou
+0.0.0.0 amusingdates.net
+0.0.0.0 honey-date4u.life


### PR DESCRIPTION
From `https://www.reddit.com/user/hancomtsa1985/comments/stgkc9/babe_today_atk_hairy_edyn_blair_asssexxxx_redhead/`

Random scam sites appers after open `https://seductivegirls.cyou/babe-today-atk-hairy-edyn-blair-asssexxxx-redhead/?feed_id=33829&_unique_id=620c3622dbbea`

`https://yvvno.amusingdates.net/c/da57dc555e50572d?s1=1205&s2=1354699&s3=&s5=backuser&click_id=1k8oo4j8m3&iexpp=1&j1=1`

`https://honey-date4u.life/?u=hxf80k9&o=l2tkpz8&cid=1k8oo4jaap`

https://whois.domaintools.com/amusingdates.net

Screenshot [NSFW]: https://i.imgur.com/2nQVb1s.png

Adult scam 



Main site is text only if any appears.