### PR TITLE
readme fix for containers; make prettier

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -68,14 +68,37 @@ folder tree, where you will find the data for `fakenews`, `social`, `gambling`, 
 
 ## Generate your own unified hosts file
 
-You have two options to generate your own hosts file.  You can do it in your own environment, or within a Docker container.  We'll cover Docker first because it's a short section.
+You have three options to generate your own hosts file. You can use our container image, build your own image, or do it in your own environment. Option #1 is easiest if you have Linux with Docker installed.
 
-### Option 1: Generate in a Docker container
+### Option 1: Use our container image (Linux only)
 
-We provide a [Dockerfile](https://github.com/StevenBlack/hosts/blob/master/Dockerfile) that you can use to create a container image with everything you need.
+> This will replace your `/etc/hosts`.
+
+We assume you have Docker available on your host. Just run the following command. Set extensions to your preference.
+
+```sh
+docker run --pull always --rm -it -v /etc/hosts:/etc/hosts \
+ghcr.io/stevenblack/hosts:latest updateHostsFile.py --auto \
+--replace --extensions gambling porn
+```
+
+If you want to add custom hosts or a whitelist, create either or both files as per
+[the instructions](#how-do-i-control-which-sources-are-unified) and add the following
+arguments _before_ `ghcr.io/stevenblack/hosts:latest` depending on which you wish to use.
+
+```sh
+-v "path/to/myhosts:/hosts/myhosts" \
+-v "path/to/whitelist:/hosts/whitelist" \
+```
+
+You can rerun this exact command later to update based on the latest available hosts (for example, add it to a weekly cron job).
+
+### Option 2: Generate your own container image
+
+We provide the [Dockerfile](https://github.com/StevenBlack/hosts/blob/master/Dockerfile) used by the previous step, which you can use to create a container image with everything you need.
 The container will contain Python 3 and all its dependency requirements, and a copy of the latest version of this repository.
 
-Build the Docker container like this:
+Build the Docker container from the root of this repo like this:
 
 ```sh
 docker build --no-cache . -t stevenblack-hosts
@@ -88,30 +111,9 @@ docker run --rm -it stevenblack-hosts updateHostsFile.py
 ```
 
 > This will create the hosts file, and remove it with the container when done, so not very
-> useful. Use the following example to automatically update your hosts file in place.
+> useful. You can use the example in option #1 to add volumes so files on your host are replaced.
 
-#### Linux example
-
-This will replace your `/etc/hosts`.
-
-Just run the following command. Set extensions to your preference.
-
-```sh
-docker run --pull always --rm -it -v /etc/hosts:/etc/hosts \
-ghcr.io/StevenBlack/hosts updateHostsFile.py --auto \
---replace --extensions gambling porn
-```
-
-If you want to add custom hosts or a whitelist, create either ot both files as per
-[the instructions](#how-do-i-control-which-sources-are-unified) and add the following
-arguments _before_ `ghcr.io/StevenBlack/hosts` depending on which you wish to use.
-
-```sh
--v "path/to/myhosts:/hosts/myhosts" \
--v "path/to/whitelist:/hosts/whitelist"
-```
-
-### Option 2: Generate it in your own environment
+### Option 3: Generate it in your own environment
 
 To generate your own amalgamated hosts files you will need Python 3.6 or later.
 

--- a/readme_template.md
+++ b/readme_template.md
@@ -1,8 +1,12 @@
 **Take Note!**
 
-* With the exception of issues and PRs regarding changes to `hosts/data/StevenBlack/hosts`, all other issues regarding the content of the produced hosts files should be made with the appropriate data source that contributed the content in question. The contact information for all of the data sources can be found in the `hosts/data/` directory.
+With the exception of issues and PRs regarding changes to
+`hosts/data/StevenBlack/hosts`, all other issues regarding the content of the
+produced hosts files should be made with the appropriate data source that
+contributed the content in question. The contact information for all of the data
+sources can be found in the `hosts/data/` directory.
 
-----
+---
 
 ![Logo](https://raw.githubusercontent.com/StevenBlack/hosts/master/.github/logo.png)
 
@@ -19,30 +23,32 @@
 # Unified hosts file @EXTENSIONS_HEADER@
 
 This repository consolidates several reputable `hosts` files, and merges them
-into a unified hosts file with duplicates removed.  A variety of tailored hosts files are provided.
+into a unified hosts file with duplicates removed. A variety of tailored hosts
+files are provided.
 
 **Therefore this repository is a hosts file aggregator.**
 
 ![Aggregator](https://raw.githubusercontent.com/StevenBlack/hosts/master/aggregator.png)
 
-
-
-
-
-* Last updated: **@GEN_DATE@**.
-* Here's the [raw hosts file @EXTENSIONS_HEADER@](https://raw.githubusercontent.com/StevenBlack/hosts/master/@SUBFOLDER@hosts) containing @NUM_ENTRIES@ entries.
-* Logo by [@Tobaloidee](https://github.com/Tobaloidee).
+- Last updated: **@GEN_DATE@**.
+- Here's the
+  [raw hosts file @EXTENSIONS_HEADER@](https://raw.githubusercontent.com/StevenBlack/hosts/master/@SUBFOLDER@hosts)
+  containing @NUM_ENTRIES@ entries.
+- Logo by [@Tobaloidee](https://github.com/Tobaloidee).
 
 ## List of all hosts file variants
 
-This repository offers [15 different host file variants](https://github.com/StevenBlack/hosts/tree/master/alternates), in addition to the base variant.
+This repository offers
+[15 different host file variants](https://github.com/StevenBlack/hosts/tree/master/alternates),
+in addition to the base variant.
 
 The **Non GitHub mirror** is the link to use for some hosts file managers like
 [Hostsman for Windows](https://www.abelhadigital.com/hostsman/) that don't work
 with GitHub download links.
 
-Host file recipe | Readme | Raw hosts | Unique domains | Non GitHub mirror
----------------- |:------:|:---------:|:--------------:|:-------------:
+| Host file recipe | Readme | Raw hosts | Unique domains | Non GitHub mirror |
+| ---------------- | :----: | :-------: | :------------: | :---------------: |
+
 @TOCROWS@
 
 **Expectation**: These unified hosts files should serve all devices, regardless
@@ -53,28 +59,40 @@ of OS.
 Updated `hosts` files from the following locations are always unified and
 included:
 
-Host file source | Home page | Raw hosts | License | Issues| Description
------------------|:---------:|:---------:|:-------:|:-----:|-------------
+| Host file source | Home page | Raw hosts | License | Issues | Description |
+| ---------------- | :-------: | :-------: | :-----: | :----: | ----------- |
+
 @SOURCEROWS@
 
 ## Extensions
 
-The unified hosts file is optionally extensible.  Extensions are used to include domains by category.  Currently, we offer the following categories: `fakenews`, `social`, `gambling`, and `porn`.
+The unified hosts file is optionally extensible. Extensions are used to include
+domains by category. Currently, we offer the following categories: `fakenews`,
+`social`, `gambling`, and `porn`.
 
-Extensions are optional, and can be combined in various ways with the base hosts file.  The combined products are stored in the [`alternates`](https://github.com/StevenBlack/hosts/tree/master/alternates) folder.
+Extensions are optional, and can be combined in various ways with the base hosts
+file. The combined products are stored in the
+[`alternates`](https://github.com/StevenBlack/hosts/tree/master/alternates)
+folder.
 
-Data for extensions are stored in the [`extensions`](https://github.com/StevenBlack/hosts/tree/master/extensions) folder. You manage extensions by curating this
-folder tree, where you will find the data for `fakenews`, `social`, `gambling`, and `porn` extension data that we maintain and provide for you.
+Data for extensions are stored in the
+[`extensions`](https://github.com/StevenBlack/hosts/tree/master/extensions)
+folder. You manage extensions by curating this folder tree, where you will find
+the data for `fakenews`, `social`, `gambling`, and `porn` extension data that we
+maintain and provide for you.
 
 ## Generate your own unified hosts file
 
-You have three options to generate your own hosts file. You can use our container image, build your own image, or do it in your own environment. Option #1 is easiest if you have Linux with Docker installed.
+You have three options to generate your own hosts file. You can use our
+container image, build your own image, or do it in your own environment. Option
+#1 is easiest if you have Linux with Docker installed.
 
 ### Option 1: Use our container image (Linux only)
 
 > This will replace your `/etc/hosts`.
 
-We assume you have Docker available on your host. Just run the following command. Set extensions to your preference.
+We assume you have Docker available on your host. Just run the following
+command. Set extensions to your preference.
 
 ```sh
 docker run --pull always --rm -it -v /etc/hosts:/etc/hosts \
@@ -82,21 +100,26 @@ ghcr.io/stevenblack/hosts:latest updateHostsFile.py --auto \
 --replace --extensions gambling porn
 ```
 
-If you want to add custom hosts or a whitelist, create either or both files as per
-[the instructions](#how-do-i-control-which-sources-are-unified) and add the following
-arguments _before_ `ghcr.io/stevenblack/hosts:latest` depending on which you wish to use.
+If you want to add custom hosts or a whitelist, create either or both files as
+per [the instructions](#how-do-i-control-which-sources-are-unified) and add the
+following arguments _before_ `ghcr.io/stevenblack/hosts:latest` depending on
+which you wish to use.
 
 ```sh
 -v "path/to/myhosts:/hosts/myhosts" \
 -v "path/to/whitelist:/hosts/whitelist" \
 ```
 
-You can rerun this exact command later to update based on the latest available hosts (for example, add it to a weekly cron job).
+You can rerun this exact command later to update based on the latest available
+hosts (for example, add it to a weekly cron job).
 
 ### Option 2: Generate your own container image
 
-We provide the [Dockerfile](https://github.com/StevenBlack/hosts/blob/master/Dockerfile) used by the previous step, which you can use to create a container image with everything you need.
-The container will contain Python 3 and all its dependency requirements, and a copy of the latest version of this repository.
+We provide the
+[Dockerfile](https://github.com/StevenBlack/hosts/blob/master/Dockerfile) used
+by the previous step, which you can use to create a container image with
+everything you need. The container will contain Python 3 and all its dependency
+requirements, and a copy of the latest version of this repository.
 
 Build the Docker container from the root of this repo like this:
 
@@ -110,8 +133,9 @@ Then run your command as such:
 docker run --rm -it stevenblack-hosts updateHostsFile.py
 ```
 
-> This will create the hosts file, and remove it with the container when done, so not very
-> useful. You can use the example in option #1 to add volumes so files on your host are replaced.
+> This will create the hosts file, and remove it with the container when done,
+> so not very useful. You can use the example in option #1 to add volumes so
+> files on your host are replaced.
 
 ### Option 3: Generate it in your own environment
 
@@ -123,7 +147,9 @@ First, install the dependencies with:
 pip3 install --user -r requirements.txt
 ```
 
-**Note** we recommend the `--user` flag which installs the required dependencies at the user level. More information about it can be found on pip [documentation](https://pip.pypa.io/en/stable/reference/pip_install/?highlight=--user#cmdoption-user).
+**Note** we recommend the `--user` flag which installs the required dependencies
+at the user level. More information about it can be found on pip
+[documentation](https://pip.pypa.io/en/stable/reference/pip_install/?highlight=--user#cmdoption-user).
 
 ### Common steps regardless of your development environment
 
@@ -133,10 +159,11 @@ To **run unit tests**, in the top-level directory, run:
 python3 testUpdateHostsFile.py
 ```
 
-The `updateHostsFile.py` script will generate a unified hosts file based on the sources in the
-local `data/` subfolder.  The script will prompt you whether it should fetch updated versions
-(from locations defined by the `update.json` text file in each source's folder). Otherwise, it
-will use the `hosts` file that's already there.
+The `updateHostsFile.py` script will generate a unified hosts file based on the
+sources in the local `data/` subfolder. The script will prompt you whether it
+should fetch updated versions (from locations defined by the `update.json` text
+file in each source's folder). Otherwise, it will use the `hosts` file that's
+already there.
 
 ```sh
 python3 updateHostsFile.py [--auto] [--replace] [--ip nnn.nnn.nnn.nnn] [--extensions ext1 ext2 ext3]
@@ -148,46 +175,46 @@ python3 updateHostsFile.py [--auto] [--replace] [--ip nnn.nnn.nnn.nnn] [--extens
 
 `--auto`, or `-a`: run the script without prompting. When `--auto` is invoked,
 
-* Hosts data sources, including extensions, are updated.
-* No extensions are included by default.  Use the `--extensions` or `-e` flag
-to include any you want.
-* Your active hosts file is *not* replaced unless you include the `--replace`
-flag.
+- Hosts data sources, including extensions, are updated.
+- No extensions are included by default. Use the `--extensions` or `-e` flag to
+  include any you want.
+- Your active hosts file is _not_ replaced unless you include the `--replace`
+  flag.
 
 `--backup`, or `-b`: Make a backup of existing hosts file(s) as you generate
 over them.
 
-`--extensions <ext1> <ext2> <ext3>`, or `-e <ext1> <ext2> <ext3>`: the names
-of subfolders below the `extensions` folder containing additional
-category-specific hosts files to include in the amalgamation. Example:
-`--extensions porn` or `-e social porn`.
+`--extensions <ext1> <ext2> <ext3>`, or `-e <ext1> <ext2> <ext3>`: the names of
+subfolders below the `extensions` folder containing additional category-specific
+hosts files to include in the amalgamation. Example: `--extensions porn` or
+`-e social porn`.
 
-`--flush-dns-cache`, or `-f`: skip the prompt for flushing the DNS cache.
-Only active when `--replace` is also active.
+`--flush-dns-cache`, or `-f`: skip the prompt for flushing the DNS cache. Only
+active when `--replace` is also active.
 
 `--ip nnn.nnn.nnn.nnn`, or `-i nnn.nnn.nnn.nnn`: the IP address to use as the
-target.  Default is `0.0.0.0`.
+target. Default is `0.0.0.0`.
 
 `--keepdomaincomments`, or `-k`: `true` (default) or `false`, keep the comments
-that appear on the same line as domains.  The default is `true`.
+that appear on the same line as domains. The default is `true`.
 
 `--noupdate`, or `-n`: skip fetching updates from hosts data sources.
 
-`--output <subfolder>`, or `-o <subfolder>`: place the generated source file
-in a subfolder.  If the subfolder does not exist, it will be created.
+`--output <subfolder>`, or `-o <subfolder>`: place the generated source file in
+a subfolder. If the subfolder does not exist, it will be created.
 
 `--replace`, or `-r`: trigger replacing your active hosts
 
 `--skipstatichosts`, or `-s`: `false` (default) or `true`, omit the standard
-section at the top, containing lines like `127.0.0.1 localhost`.  This is
-useful for configuring proximate DNS services on the local network.
+section at the top, containing lines like `127.0.0.1 localhost`. This is useful
+for configuring proximate DNS services on the local network.
 
 `--nogendata`, or `-g`: `false` (default) or `true`, skip the generation of the
-readmeData.json file used for generating readme.md files.  This is useful if you are
-generating host files with additional whitelists or blacklists and want to keep your
-local checkout of this repo unmodified.
+readmeData.json file used for generating readme.md files. This is useful if you
+are generating host files with additional whitelists or blacklists and want to
+keep your local checkout of this repo unmodified.
 
-`--compress`, or `-c`: `false` (default) or `true`, *Compress* the hosts file
+`--compress`, or `-c`: `false` (default) or `true`, _Compress_ the hosts file
 ignoring non-necessary lines (empty lines and comments) and putting multiple
 domains in each line. Reducing the number of lines of the hosts file improves
 the performances under Windows (with DNS Client service enabled).
@@ -197,34 +224,33 @@ each domain on a separate line. This is necessary because many implementations
 of URL blockers that rely on `hosts` files do not conform to the standard which
 allows multiple hosts on a single line.
 
-`--blacklist <blacklistfile>`, or `-x <blacklistfile>`: Append the given blacklist file
-in hosts format to the generated hosts file.
+`--blacklist <blacklistfile>`, or `-x <blacklistfile>`: Append the given
+blacklist file in hosts format to the generated hosts file.
 
-`--whitelist <whitelistfile>`, or `-w <whitelistfile>`: Use the given whitelist file
-to remove hosts from the generated hosts file.
+`--whitelist <whitelistfile>`, or `-w <whitelistfile>`: Use the given whitelist
+file to remove hosts from the generated hosts file.
 
 ## How do I control which sources are unified?
 
-Add one or more *additional* sources, each in a subfolder of the `data/`
-folder, and specify the `url` key in its `update.json` file.
+Add one or more _additional_ sources, each in a subfolder of the `data/` folder,
+and specify the `url` key in its `update.json` file.
 
-Add one or more *optional* extensions, which originate from subfolders of the
-`extensions/` folder.  Again the url in `update.json` controls where this
+Add one or more _optional_ extensions, which originate from subfolders of the
+`extensions/` folder. Again the url in `update.json` controls where this
 extension finds its updates.
 
-Create an *optional* `blacklist` file. The contents of this file (containing a
+Create an _optional_ `blacklist` file. The contents of this file (containing a
 listing of additional domains in `hosts` file format) are appended to the
-unified hosts file during the update process. A sample `blacklist` is
-included, and may be modified as you need.
+unified hosts file during the update process. A sample `blacklist` is included,
+and may be modified as you need.
 
-* NOTE: The `blacklist` is not tracked by git, so any changes you make won't
-be overridden when you `git pull` this repo from `origin` in the future.
+- NOTE: The `blacklist` is not tracked by git, so any changes you make won't be
+  overridden when you `git pull` this repo from `origin` in the future.
 
 ### How do I include my own custom domain mappings?
 
-If you have custom hosts records, place them in file `myhosts`.  The contents
-of this file are prepended to the unified hosts file during the update
-process.
+If you have custom hosts records, place them in file `myhosts`. The contents of
+this file are prepended to the unified hosts file during the update process.
 
 The `myhosts` file is not tracked by git, so any changes you make won't be
 overridden when you `git pull` this repo from `origin` in the future.
@@ -234,41 +260,52 @@ overridden when you `git pull` this repo from `origin` in the future.
 The domains you list in the `whitelist` file are excluded from the final hosts
 file.
 
-The `whitelist` uses partial matching.  Therefore if you whitelist
-`google-analytics.com`, that domain and all its subdomains won't be merged
-into the final hosts file.
+The `whitelist` uses partial matching. Therefore if you whitelist
+`google-analytics.com`, that domain and all its subdomains won't be merged into
+the final hosts file.
 
 The `whitelist` is not tracked by git, so any changes you make won't be
 overridden when you `git pull` this repo from `origin` in the future.
 
 ## How can I contribute hosts records?
 
-If you discover sketchy domains you feel should be included here, here are some ways to contribute them.
+If you discover sketchy domains you feel should be included here, here are some
+ways to contribute them.
 
 ### Option 1: contact one of our hosts sources
 
-The best way to get new domains included is to submit an issue to any of the data providers whose home pages are [listed here](https://github.com/StevenBlack/hosts#sources-of-hosts-data-unified-in-this-variant). This is best because once you submit new domains, they will be curated and updated by the dedicated folks who maintain these sources.
+The best way to get new domains included is to submit an issue to any of the
+data providers whose home pages are
+[listed here](https://github.com/StevenBlack/hosts#sources-of-hosts-data-unified-in-this-variant).
+This is best because once you submit new domains, they will be curated and
+updated by the dedicated folks who maintain these sources.
 
 ### Option 2: Fork this repository, add your domains to Steven Black's personal data file, and submit a pull request
 
-Fork this hosts this repo and add your links to [https://github.com/StevenBlack/hosts/blob/master/data/StevenBlack/hosts](https://github.com/StevenBlack/hosts/blob/master/data/StevenBlack/hosts).
+Fork this hosts this repo and add your links to
+[https://github.com/StevenBlack/hosts/blob/master/data/StevenBlack/hosts](https://github.com/StevenBlack/hosts/blob/master/data/StevenBlack/hosts).
 
 Then, submit a pull request.
 
-**WARNING**: this is less desirable than Option 1 because the ongoing curation falls on us. So this creates more work for us.
+**WARNING**: this is less desirable than Option 1 because the ongoing curation
+falls on us. So this creates more work for us.
 
 ### Option 3: create your own hosts list as a repo on GitHub
 
-If you're able to curate your own collection of sketchy domains, then curate your own hosts list.  Then signal the existence of your repo as [a new issue](https://github.com/StevenBlack/hosts/issues) and we may include your new repo into the collection of sources we pull whenever we create new versions.
+If you're able to curate your own collection of sketchy domains, then curate
+your own hosts list. Then signal the existence of your repo as
+[a new issue](https://github.com/StevenBlack/hosts/issues) and we may include
+your new repo into the collection of sources we pull whenever we create new
+versions.
 
 ## What is a hosts file?
 
-A hosts file, named `hosts` (with no file extension), is a plain-text file
-used by all operating systems to map hostnames to IP addresses.
+A hosts file, named `hosts` (with no file extension), is a plain-text file used
+by all operating systems to map hostnames to IP addresses.
 
-In most operating systems, the `hosts` file is preferential to `DNS`.
-Therefore if a domain name is resolved by the `hosts` file, the request never
-leaves your computer.
+In most operating systems, the `hosts` file is preferential to `DNS`. Therefore
+if a domain name is resolved by the `hosts` file, the request never leaves your
+computer.
 
 Having a smart `hosts` file goes a long way towards blocking malware, adware,
 and other irritants.
@@ -288,33 +325,40 @@ lines to your hosts file will do it:
 
 ## We recommend using `0.0.0.0` instead of `127.0.0.1`
 
-Traditionally most host files use `127.0.0.1`, the *loopback address*, to establish an IP connection to the local machine.
+Traditionally most host files use `127.0.0.1`, the _loopback address_, to
+establish an IP connection to the local machine.
 
-We prefer to use `0.0.0.0`, which is defined as a non-routable meta-address used to designate an invalid, unknown, or non-applicable target.
+We prefer to use `0.0.0.0`, which is defined as a non-routable meta-address used
+to designate an invalid, unknown, or non-applicable target.
 
-Using `0.0.0.0` is empirically faster, possibly because there's no wait for a timeout resolution. It also does not
-interfere with a web server that may be running on the local PC.
+Using `0.0.0.0` is empirically faster, possibly because there's no wait for a
+timeout resolution. It also does not interfere with a web server that may be
+running on the local PC.
 
 ## Why not use `0` instead of `0.0.0.0`?
 
-We tried that.  Using `0` doesn't work universally.
+We tried that. Using `0` doesn't work universally.
 
 ## Location of your hosts file
 
-To modify your current `hosts` file, look for it in the following places and modify it with a text
-editor.
+To modify your current `hosts` file, look for it in the following places and
+modify it with a text editor.
 
-* **macOS (until 10.14.x macOS Mojave), iOS, Android, Linux**: `/etc/hosts` file.
-* **macOS Catalina:** `/private/etc/hosts` file.
-* **Windows**: `%SystemRoot%\system32\drivers\etc\hosts` file.
+- **macOS (until 10.14.x macOS Mojave), iOS, Android, Linux**: `/etc/hosts`
+  file.
+- **macOS Catalina:** `/private/etc/hosts` file.
+- **Windows**: `%SystemRoot%\system32\drivers\etc\hosts` file.
 
 ## Gentoo
 
-Gentoo users may find [`sb-hosts`](https://github.com/PF4Public/gentoo-overlay/tree/master/net-misc/sb-hosts) in [::pf4public](https://github.com/PF4Public/gentoo-overlay) Gentoo overlay
+Gentoo users may find
+[`sb-hosts`](https://github.com/PF4Public/gentoo-overlay/tree/master/net-misc/sb-hosts)
+in [::pf4public](https://github.com/PF4Public/gentoo-overlay) Gentoo overlay
 
 ## NixOS
 
-To install hosts file on your machine add the following into your `configuration.nix`:
+To install hosts file on your machine add the following into your
+`configuration.nix`:
 
 ```nix
 {
@@ -325,13 +369,14 @@ To install hosts file on your machine add the following into your `configuration
 }
 ```
 
-* NOTE: Change `hostsPath` if you need other versions of hosts file.
-* NOTE: The call to `fetchurl` is impure.
-Use `fetchFromGitHub` with the exact commit if you want to always get the same result.
+- NOTE: Change `hostsPath` if you need other versions of hosts file.
+- NOTE: The call to `fetchurl` is impure. Use `fetchFromGitHub` with the exact
+  commit if you want to always get the same result.
 
 ### Nix Flake
 
-NixOS installations which are managed through *flakes* can use the hosts file like this:
+NixOS installations which are managed through _flakes_ can use the hosts file
+like this:
 
 ```nix
 {
@@ -366,41 +411,51 @@ The hosts extensions are also available with the following options:
 
 (NOTE: See also some third-party Hosts managers, listed below.)
 
-On Linux and macOS, run the Python script. On Windows more
-work is required due to compatibility issues so it's preferable to run the batch file as follows:
+On Linux and macOS, run the Python script. On Windows more work is required due
+to compatibility issues so it's preferable to run the batch file as follows:
 
 ```sh
 updateHostsWindows.bat
 ```
 
-This file **MUST** be run in command prompt with administrator privileges in
-the repository directory. In addition to updating the hosts file, it can also
+This file **MUST** be run in command prompt with administrator privileges in the
+repository directory. In addition to updating the hosts file, it can also
 replace the existing hosts file, and reload the DNS cache. It goes without
 saying that for this to work, you must be connected to the internet.
 
-To open a command prompt as administrator in the repository's directory, do the following:
+To open a command prompt as administrator in the repository's directory, do the
+following:
 
-* **Windows XP**: Start → Run → `cmd`
-* **Windows Vista, 7**: Start Button → type `cmd` → right-click Command Prompt → "Run as Administrator"
-* **Windows 8**: Start → Swipe Up → All Apps → Windows System → right-click Command Prompt → "Run as Administrator"
-* **Windows 10**: Start Button → type `cmd` → right-click Command Prompt → "Run as Administrator"
+- **Windows XP**: Start → Run → `cmd`
+- **Windows Vista, 7**: Start Button → type `cmd` → right-click Command Prompt →
+  "Run as Administrator"
+- **Windows 8**: Start → Swipe Up → All Apps → Windows System → right-click
+  Command Prompt → "Run as Administrator"
+- **Windows 10**: Start Button → type `cmd` → right-click Command Prompt → "Run
+  as Administrator"
 
-You can also refer to the "Third-Party Hosts Managers" section for further recommended solutions from third parties.
+You can also refer to the "Third-Party Hosts Managers" section for further
+recommended solutions from third parties.
 
 ### Warning: Using this `hosts` file in Windows may require disabling DNS Cache service
 
-Windows has issues with larger hosts files. Recent changes in security within Windows 10 denies
-access to changing services via other tools except registry hacks. Use the `disable-dnscache-service-win.cmd`
-file to make proper changes to the Windows registry. You will need to reboot your device once that's done.
-See the [the comments within the `cmd` file](https://github.com/StevenBlack/hosts/blob/master/disable-dnscache-service-win.bat)
+Windows has issues with larger hosts files. Recent changes in security within
+Windows 10 denies access to changing services via other tools except registry
+hacks. Use the `disable-dnscache-service-win.cmd` file to make proper changes to
+the Windows registry. You will need to reboot your device once that's done. See
+the
+[the comments within the `cmd` file](https://github.com/StevenBlack/hosts/blob/master/disable-dnscache-service-win.bat)
 for more details.
 
 ## Reloading hosts file
 
-Your operating system will cache DNS lookups. You can either reboot or run the following commands to
-manually flush your DNS cache once the new hosts file is in place.
+Your operating system will cache DNS lookups. You can either reboot or run the
+following commands to manually flush your DNS cache once the new hosts file is
+in place.
 
-The Google Chrome browser may require manually cleaning up its DNS Cache on `chrome://net-internals/#dns` page to thereafter see the changes in your hosts file. See: <https://superuser.com/questions/723703>
+The Google Chrome browser may require manually cleaning up its DNS Cache on
+`chrome://net-internals/#dns` page to thereafter see the changes in your hosts
+file. See: <https://superuser.com/questions/723703>
 
 ### Windows
 
@@ -414,30 +469,35 @@ ipconfig /flushdns
 
 Open a Terminal and run with root privileges:
 
-* **Debian/Ubuntu** `sudo service network-manager restart`
-* **Linux Mint** `sudo /etc/init.d/dns-clean start`
-* **Linux with systemd**: `sudo systemctl restart network.service`
-* **Fedora Linux**: `sudo systemctl restart NetworkManager.service`
-* **Arch Linux/Manjaro with Network Manager**: `sudo systemctl restart NetworkManager.service`
-* **Arch Linux/Manjaro with Wicd**: `sudo systemctl restart wicd.service`
-* **RHEL/Centos**: `sudo /etc/init.d/network restart`
-* **FreeBSD**: `sudo service nscd restart`
+- **Debian/Ubuntu** `sudo service network-manager restart`
+- **Linux Mint** `sudo /etc/init.d/dns-clean start`
+- **Linux with systemd**: `sudo systemctl restart network.service`
+- **Fedora Linux**: `sudo systemctl restart NetworkManager.service`
+- **Arch Linux/Manjaro with Network Manager**:
+  `sudo systemctl restart NetworkManager.service`
+- **Arch Linux/Manjaro with Wicd**: `sudo systemctl restart wicd.service`
+- **RHEL/Centos**: `sudo /etc/init.d/network restart`
+- **FreeBSD**: `sudo service nscd restart`
 
-  To enable the `nscd` daemon initially, it is recommended that you run the following commands:
+  To enable the `nscd` daemon initially, it is recommended that you run the
+  following commands:
 
   ```sh
   sudo sysrc nscd_enable="YES"
   sudo service nscd start
   ```
 
-  Then modify the `hosts` line in your `/etc/nsswitch.conf` file to the following:
+  Then modify the `hosts` line in your `/etc/nsswitch.conf` file to the
+  following:
 
   ```text
   hosts: cache files dns
   ```
 
-* **NixOS**: The `nscd.service` is automatically restarted when the option `networking.extraHosts` was changed.
-* **Others**: Consult [this Wikipedia article](https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system).
+- **NixOS**: The `nscd.service` is automatically restarted when the option
+  `networking.extraHosts` was changed.
+- **Others**: Consult
+  [this Wikipedia article](https://en.wikipedia.org/wiki/Hosts_%28file%29#Location_in_the_file_system).
 
 ### macOS
 
@@ -449,10 +509,14 @@ sudo dscacheutil -flushcache;sudo killall -HUP mDNSResponder
 
 ## Release management
 
-This repository uses [release-it](https://github.com/release-it/release-it), an excellent CLI release
-tool for GitHub repos and npm packages, to automate creating [releases](https://github.com/StevenBlack/hosts/releases).
-This is why the [package.json](https://github.com/StevenBlack/hosts/blob/master/package.json) and
-[.release-it.json](https://github.com/StevenBlack/hosts/blob/master/.release-it.json) files are bundled.
+This repository uses [release-it](https://github.com/release-it/release-it), an
+excellent CLI release tool for GitHub repos and npm packages, to automate
+creating [releases](https://github.com/StevenBlack/hosts/releases). This is why
+the
+[package.json](https://github.com/StevenBlack/hosts/blob/master/package.json)
+and
+[.release-it.json](https://github.com/StevenBlack/hosts/blob/master/.release-it.json)
+files are bundled.
 
 ## Goals of this unified hosts file
 
@@ -463,38 +527,97 @@ The goals of this repo are to:
 3. de-dupe the resultant combined list,
 4. and keep the resultant file reasonably sized.
 
-A high-quality source is defined here as one that is actively curated.  A
-hosts source should be frequently updated by its maintainers with both
-additions and removals.  The larger the hosts file, the higher the level of
-curation is expected.
+A high-quality source is defined here as one that is actively curated. A hosts
+source should be frequently updated by its maintainers with both additions and
+removals. The larger the hosts file, the higher the level of curation is
+expected.
 
 It is expected that this unified hosts file will serve both desktop and mobile
 devices under a variety of operating systems.
 
 ## Third-Party Hosts Managers
 
-* [Unified Hosts AutoUpdate](https://github.com/ScriptTiger/Unified-Hosts-AutoUpdate "Unified Hosts AutoUpdate") (for Windows): The Unified Hosts AutoUpdate package is purpose-built for this unified hosts project as well as in active development by community members. You can install and uninstall any blacklist and keep it automatically up to date, and can be placed in a shared network location and deployed across an organization via group policies. And since it is in active development by community members, your bug reports, feature requests, and other feedback are most welcome.
-* [ViHoMa](https://github.com/cmabad/ViHoMa) is a Visual Hosts file Manager, written in Java, by Christian Martínez.  Check it out!
+- [Unified Hosts AutoUpdate](https://github.com/ScriptTiger/Unified-Hosts-AutoUpdate "Unified Hosts AutoUpdate")
+  (for Windows): The Unified Hosts AutoUpdate package is purpose-built for this
+  unified hosts project as well as in active development by community members.
+  You can install and uninstall any blacklist and keep it automatically up to
+  date, and can be placed in a shared network location and deployed across an
+  organization via group policies. And since it is in active development by
+  community members, your bug reports, feature requests, and other feedback are
+  most welcome.
+- [ViHoMa](https://github.com/cmabad/ViHoMa) is a Visual Hosts file Manager,
+  written in Java, by Christian Martínez. Check it out!
 
 ## Interesting Applications
 
-* [Hosts-BL](https://github.com/ScriptTiger/Hosts-BL "Hosts-BL") is a simple tool to handle hosts file black lists. It can remove comments, remove duplicates, compress to 9 domains per line, add IPv6 entries. In addition, it can also convert black lists to multiple other black list formats compatible with other software, such as dnsmasq, DualServer, RPZ, Privoxy, and Unbound, to name a few.
-* [Host Minder](https://github.com/jeremehancock/hostminder#readme) is a simple GUI that allows you to easily update your /etc/hosts file to one of four consolidated hosts files from StevenBlack/hosts. It is provided as a deb package and comes pre-installed on [UbuntuCE](https://ubuntuce.com/).
-* [Maza ad blocking](https://github.com/tanrax/maza-ad-blocking) is a bash script that automatically updates host file. You can also update a fresh copy. And each time it generates a dnsmasq-compatible configuration file. Fast installation, compatible with MacOS, Linux and BSD.
-* [Hostile](https://github.com/feross/hostile) is a nifty command line utility to easily add or remove domains from your hosts file.  If our hosts files are too aggressive for you, you can use `hostile` to remove domains, or you can use `hostile` in a bash script to automate a post process each time you download fresh versions of hosts.
-* [macOS Scripting for Configuration, Backup and Restore](https://github.com/tiiiecherle/osx_install_config) helps customizing, re-installing and using macOS. It also provides a [script](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/launchd_and_script/hosts_file_generator.sh) to install and update the hosts file using this project on macOS. In combination with a [launchd](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/launchd_and_script/com.hostsfile.install_update.plist) it updates the hosts file every x days (default is 4). To install both, download the GitHub repo and run the [install script](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/install_hosts_file_generator_and_launchdservice.sh) from the directory one level up.
-* [Pi-hole](https://pi-hole.net/) is a network-wide DHCP server and ad blocker that runs on [Raspberry Pi](https://en.wikipedia.org/wiki/Raspberry_Pi). Pi-hole uses this repository as one of its sources.
-* [Block ads and malware via local BIND9 DNS server](https://github.com/mueller-ma/block-ads-via-dns "Block ads and malware via local DNS server") (for Debian, Raspbian & Ubuntu): Set up a local DNS server with a `/etc/bind/named.conf.blocked` file, sourced from here.
-* [Block ads, malware, and deploy parental controls via local DualServer DNS/DHCP server](https://scripttiger.github.io/dualserver/ "Block ads, malware, and deploy parental controls via local DualServer DNS/DHCP server") (for BSD, Windows & Linux): Set up a blacklist for everyone on your network using the power of the unified hosts reformatted for DualServer. And if you're on Windows, this project also maintains an update script to make updating DualServer's blacklist even easier.
-* [Blocking ads and malwares with unbound](https://deadc0de.re/articles/unbound-blocking-ads.html "Blocking ads and malwares with unbound") – [Unbound](https://www.unbound.net/ "Unbound is a validating, recursive, and caching DNS resolver.") is a validating, recursive, and caching DNS resolver.
-* [dnsmasq conversion script](https://gist.github.com/erlepereira/c11f4f7a3f60cd2071e79018e895fc8a#file-dnsmasq-antimalware) This GitHub gist has a short shell script (bash, will work on any 'nix) and uses `wget` & `awk` present in most distros, to fetch a specified hosts file and convert it to the format required by dnsmasq. Supports IPv4 and IPv6. Designed to be used as either a shell script, or can be dropped into `/etc/cron.weekly` (or wherever suits). The script is short and easily edited, also has a short document attached with notes on dnsmasq setup.
-* [BlackHosts - Command Line Installer/Updater](https://github.com/Lateralus138/blackhosts) This is a cross-platform command line utility to help install/update hosts files found at this repository.
-* [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Combining-Blocklists) provides a tool to build block lists from local and remote lists in common formats.
+- [Hosts-BL](https://github.com/ScriptTiger/Hosts-BL "Hosts-BL") is a simple
+  tool to handle hosts file black lists. It can remove comments, remove
+  duplicates, compress to 9 domains per line, add IPv6 entries. In addition, it
+  can also convert black lists to multiple other black list formats compatible
+  with other software, such as dnsmasq, DualServer, RPZ, Privoxy, and Unbound,
+  to name a few.
+- [Host Minder](https://github.com/jeremehancock/hostminder#readme) is a simple
+  GUI that allows you to easily update your /etc/hosts file to one of four
+  consolidated hosts files from StevenBlack/hosts. It is provided as a deb
+  package and comes pre-installed on [UbuntuCE](https://ubuntuce.com/).
+- [Maza ad blocking](https://github.com/tanrax/maza-ad-blocking) is a bash
+  script that automatically updates host file. You can also update a fresh copy.
+  And each time it generates a dnsmasq-compatible configuration file. Fast
+  installation, compatible with MacOS, Linux and BSD.
+- [Hostile](https://github.com/feross/hostile) is a nifty command line utility
+  to easily add or remove domains from your hosts file. If our hosts files are
+  too aggressive for you, you can use `hostile` to remove domains, or you can
+  use `hostile` in a bash script to automate a post process each time you
+  download fresh versions of hosts.
+- [macOS Scripting for Configuration, Backup and Restore](https://github.com/tiiiecherle/osx_install_config)
+  helps customizing, re-installing and using macOS. It also provides a
+  [script](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/launchd_and_script/hosts_file_generator.sh)
+  to install and update the hosts file using this project on macOS. In
+  combination with a
+  [launchd](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/launchd_and_script/com.hostsfile.install_update.plist)
+  it updates the hosts file every x days (default is 4). To install both,
+  download the GitHub repo and run the
+  [install script](https://github.com/tiiiecherle/osx_install_config/blob/master/09_launchd/9b_run_on_boot/root/1_hosts_file/install_hosts_file_generator_and_launchdservice.sh)
+  from the directory one level up.
+- [Pi-hole](https://pi-hole.net/) is a network-wide DHCP server and ad blocker
+  that runs on [Raspberry Pi](https://en.wikipedia.org/wiki/Raspberry_Pi).
+  Pi-hole uses this repository as one of its sources.
+- [Block ads and malware via local BIND9 DNS server](https://github.com/mueller-ma/block-ads-via-dns "Block ads and malware via local DNS server")
+  (for Debian, Raspbian & Ubuntu): Set up a local DNS server with a
+  `/etc/bind/named.conf.blocked` file, sourced from here.
+- [Block ads, malware, and deploy parental controls via local DualServer DNS/DHCP server](https://scripttiger.github.io/dualserver/ "Block ads, malware, and deploy parental controls via local DualServer DNS/DHCP server")
+  (for BSD, Windows & Linux): Set up a blacklist for everyone on your network
+  using the power of the unified hosts reformatted for DualServer. And if you're
+  on Windows, this project also maintains an update script to make updating
+  DualServer's blacklist even easier.
+- [Blocking ads and malwares with unbound](https://deadc0de.re/articles/unbound-blocking-ads.html "Blocking ads and malwares with unbound")
+  –
+  [Unbound](https://www.unbound.net/ "Unbound is a validating, recursive, and caching DNS resolver.")
+  is a validating, recursive, and caching DNS resolver.
+- [dnsmasq conversion script](https://gist.github.com/erlepereira/c11f4f7a3f60cd2071e79018e895fc8a#file-dnsmasq-antimalware)
+  This GitHub gist has a short shell script (bash, will work on any 'nix) and
+  uses `wget` & `awk` present in most distros, to fetch a specified hosts file
+  and convert it to the format required by dnsmasq. Supports IPv4 and IPv6.
+  Designed to be used as either a shell script, or can be dropped into
+  `/etc/cron.weekly` (or wherever suits). The script is short and easily edited,
+  also has a short document attached with notes on dnsmasq setup.
+- [BlackHosts - Command Line Installer/Updater](https://github.com/Lateralus138/blackhosts)
+  This is a cross-platform command line utility to help install/update hosts
+  files found at this repository.
+- [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Combining-Blocklists)
+  provides a tool to build block lists from local and remote lists in common
+  formats.
 
 ## Contribute
 
-Please read our [Contributing Guide](https://github.com/StevenBlack/hosts/blob/master/contributing.md). Among other things, this explains how we organize files and folders in this repository.
+Please read our
+[Contributing Guide](https://github.com/StevenBlack/hosts/blob/master/contributing.md).
+Among other things, this explains how we organize files and folders in this
+repository.
 
-We are always interested in discovering well-curated sources of hosts.  If you find one, please open an [issue](https://github.com/StevenBlack/hosts/issues) to draw our attention.
+We are always interested in discovering well-curated sources of hosts. If you
+find one, please open an [issue](https://github.com/StevenBlack/hosts/issues) to
+draw our attention.
 
-Before you create or respond to any issue, please read our [code of conduct](https://github.com/StevenBlack/hosts/blob/master/code_of_conduct.md).
+Before you create or respond to any issue, please read our
+[code of conduct](https://github.com/StevenBlack/hosts/blob/master/code_of_conduct.md).


### PR DESCRIPTION
This has 2 commits doing 2 separate things in the readme:

1. Fix the container syntax (it has capitals there, and those never work) and move that to option 1 as it works well and the previous option 1 already assumed the availability of Docker - See the first commit for those changes
2. Run [`prettier`](https://prettier.io/) over the markdown, to make it readable without a renderer. Let me know if you like that. I can highly recommend it for anything that it supports, as it makes things nicely readable (except for python, for which they recommend `black`, which does the exact same thing).