### PR TITLE
telemetry.acronis.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2238,3 +2238,6 @@
 # Added August 12, 2022
 0.0.0.0 nl-crypto.com
 0.0.0.0 evri-package-gb.web.app
+
+# Added August 13, 2022
+0.0.0.0 telemetry.acronis.com


### PR DESCRIPTION
I found it in logs. 
If you using acronis software, then app in background collect telemetry data. IMHO can be blocked and improve privacy. 
Ping every hour. 
https://domain.glass/telemetry.acronis.com