### PR TITLE
fake tv stream sites

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2284,3 +2284,9 @@
 0.0.0.0 quinni.cyou
 0.0.0.0 www.alenai.cyou
 0.0.0.0 alenai.cyou
+
+# Added September 5, 2022
+0.0.0.0 telewizja-online.net
+0.0.0.0 bramka.org
+0.0.0.0 ustreamix.su
+0.0.0.0 inatv.pl


### PR DESCRIPTION
Some polish fake tv stream sites. Some links on sites are risky. Other want payment via SMS premium fot grant access to unknown content quality,

