### PR TITLE
Add malware domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2368,3 +2368,58 @@
 
 # Added November 27, 2022
 0.0.0.0 crmt.livejasmin.com
+
+# Added December 4, 2022. Malware domains using TXT record to transfer powershell scripts.
+0.0.0.0 wmail-endpoint.com
+0.0.0.0 wmail-blog.com
+0.0.0.0 wmail-chat.com
+0.0.0.0 wmail-cdn.com
+0.0.0.0 wmail-schnellvpn.com
+0.0.0.0 fairu-endpoint.com
+0.0.0.0 fairu-blog.com
+0.0.0.0 fairu-chat.com
+0.0.0.0 fairu-cdn.com
+0.0.0.0 fairu-schnellvpn.com
+0.0.0.0 bideo-endpoint.com
+0.0.0.0 bideo-blog.com
+0.0.0.0 bideo-chat.com
+0.0.0.0 bideo-cdn.com
+0.0.0.0 bideo-schnellvpn.com
+0.0.0.0 privatproxy-endpoint.com
+0.0.0.0 privatproxy-blog.com
+0.0.0.0 privatproxy-chat.com
+0.0.0.0 privatproxy-cdn.com
+0.0.0.0 privatproxy-schnellvpn.com
+0.0.0.0 ahoravideo-endpoint.com
+0.0.0.0 ahoravideo-blog.com
+0.0.0.0 ahoravideo-chat.com
+0.0.0.0 ahoravideo-cdn.com
+0.0.0.0 ahoravideo-schnellvpn.com
+0.0.0.0 wmail-endpoint.xyz
+0.0.0.0 wmail-blog.xyz
+0.0.0.0 wmail-chat.xyz
+0.0.0.0 wmail-cdn.xyz
+0.0.0.0 wmail-schnellvpn.xyz
+0.0.0.0 fairu-endpoint.xyz
+0.0.0.0 fairu-blog.xyz
+0.0.0.0 fairu-chat.xyz
+0.0.0.0 fairu-cdn.xyz
+0.0.0.0 fairu-schnellvpn.xyz
+0.0.0.0 bideo-endpoint.xyz
+0.0.0.0 bideo-blog.xyz
+0.0.0.0 bideo-chat.xyz
+0.0.0.0 bideo-cdn.xyz
+0.0.0.0 bideo-schnellvpn.xyz
+0.0.0.0 privatproxy-endpoint.xyz
+0.0.0.0 privatproxy-blog.xyz
+0.0.0.0 privatproxy-chat.xyz
+0.0.0.0 privatproxy-cdn.xyz
+0.0.0.0 privatproxy-schnellvpn.xyz
+0.0.0.0 ahoravideo-endpoint.xyz
+0.0.0.0 ahoravideo-blog.xyz
+0.0.0.0 ahoravideo-chat.xyz
+0.0.0.0 ahoravideo-cdn.xyz
+0.0.0.0 ahoravideo-schnellvpn.xyz
+
+# Added December 4, 2022. Malware domain distributing payloads
+0.0.0.0 cesareurope.com


### PR DESCRIPTION
These domains have been discovered in a malware powershell script. 

The first set of domains contains TXT records with powershell code. Some of them are dormant/backup, at least one of them contains an active payload. The powershell payload in turn points to another domain which distributes another payload to specific targeted machines.