### PR TITLE
Clean-up batch scripts

### DIFF
--- a/disable-dnscache-service-win.bat
+++ b/disable-dnscache-service-win.bat
@@ -23,12 +23,13 @@ exit /b 0
 
 
 :UACPrompt
-    echo Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
+    set "output_file=%TEMP%\getadmin.vbs"
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%output_file%"
     set params= %*
-    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
+    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%output_file%"
 
-    wscript.exe "%TEMP%\getadmin.vbs"
-    del "%TEMP%\getadmin.vbs"
+    wscript.exe "%output_file%"
+    del "%output_file%"
 exit /b
 
 :gotAdmin

--- a/disable-dnscache-service-win.bat
+++ b/disable-dnscache-service-win.bat
@@ -1,5 +1,5 @@
 @echo off
-
+setlocal
 title Disable DNS Cache Service
 
 :: Check if we are an administrator. If not, exit immediately.

--- a/disable-dnscache-service-win.bat
+++ b/disable-dnscache-service-win.bat
@@ -14,30 +14,32 @@ if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
 :: If the error flag set, we do not have admin rights.
 if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
-    goto UACPrompt
+    call :UACPrompt
 ) else (
-    goto gotAdmin
+    call :gotAdmin
 )
 
-:UACPrompt
-echo Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
-set params= %*
-echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
+exit /b 0
 
-wscript.exe "%TEMP%\getadmin.vbs"
-del "%TEMP%\getadmin.vbs"
+
+:UACPrompt
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
+    set params= %*
+    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
+
+    wscript.exe "%TEMP%\getadmin.vbs"
+    del "%TEMP%\getadmin.vbs"
 exit /b
 
 :gotAdmin
-
-:SCset
-:: VALUE
-:: 2 (Automatic) (DEFAULT)
-:: 4 (Disabled) (to prevent network freeze after applying a huge hosts file)
-::
-:: See https://superuser.com/a/1277960
-::
-reg add "HKLM\SYSTEM\CurrentControlSet\services\Dnscache" /v Start /t REG_DWORD /d 4 /f
-echo Reboot your system now!
-echo.
-pause
+    :: VALUE
+    :: 2 (Automatic) (DEFAULT)
+    :: 4 (Disabled) (to prevent network freeze after applying a huge hosts file)
+    ::
+    :: See https://superuser.com/a/1277960
+    ::
+    reg add "HKLM\SYSTEM\CurrentControlSet\services\Dnscache" /v Start /t REG_DWORD /d 4 /f
+    echo Reboot your system now!
+    echo.
+    pause
+exit /b 0

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -34,12 +34,13 @@ if %ERRORLEVEL% neq 0 (
 )
 
 :UACPrompt
-echo Set UAC = CreateObject^("Shell.Application"^) > "%TEMP%\getadmin.vbs"
+set "output_file=%TEMP%\getadmin.vbs"
+echo Set UAC = CreateObject^("Shell.Application"^) > "%output_file%"
 set params= %*
-echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%TEMP%\getadmin.vbs"
+echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%output_file%"
 
-wscript.exe "%TEMP%\getadmin.vbs"
-del "%TEMP%\getadmin.vbs"
+wscript.exe "%output_file%"
+del "%output_file%"
 exit /b
 
 :gotAdmin

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -28,20 +28,20 @@ if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
 :: If the error flag set, we do not have admin rights.
 if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
-    goto UACPrompt
+    call :UACPrompt
 ) else (
     goto gotAdmin
 )
 
 :UACPrompt
-set "output_file=%TEMP%\getadmin.vbs"
-echo Set UAC = CreateObject^("Shell.Application"^) > "%output_file%"
-set params= %*
-echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%output_file%"
+    set "output_file=%TEMP%\getadmin.vbs"
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%output_file%"
+    set params= %*
+    echo UAC.ShellExecute "cmd.exe", "/c ""%~s0"" %params:"=""%", "", "runas", 1 >> "%output_file%"
 
-wscript.exe "%output_file%"
-del "%output_file%"
-exit /b
+    wscript.exe "%output_file%"
+    del "%output_file%"
+exit /b 0
 
 :gotAdmin
 cd /d "%~dp0"

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -13,13 +13,16 @@
 setlocal
 title Update Hosts
 
+set "calcs_executable=%SYSTEMROOT%\SysWOW64\cacls.exe"
+set "calcs_file=%SYSTEMROOT%\system32\config\system"
+
 :: Check if we are an administrator. If not, exit immediately.
 :: BatchGotAdmin
 :: Check for permissions
 if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
-    >nul 2>&1 "%SYSTEMROOT%\SysWOW64\cacls.exe" "%SYSTEMROOT%\SysWOW64\config\system"
+    >nul 2>&1 "%calcs_executable%" "%calcs_file%"
 ) else (
-    >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+    >nul 2>&1 "%calcs_executable%" "%calcs_file%"
 )
 
 :: If the error flag set, we do not have admin rights.

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -32,6 +32,7 @@ if %ERRORLEVEL% neq 0 (
 
 exit /b 0
 
+
 :UACPrompt
     set "output_file=%TEMP%\getadmin.vbs"
     echo Set UAC = CreateObject^("Shell.Application"^) > "%output_file%"

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -47,9 +47,10 @@ exit /b
 cd /d "%~dp0"
 
 :BackupHosts
+set "common_prefix=%WINDIR%\System32\drivers\etc\hosts"
 :: Backup the default hosts file
-if not exist "%WINDIR%\System32\drivers\etc\hosts.skel" (
-    copy /v "%WINDIR%\System32\drivers\etc\hosts" "%WINDIR%\System32\drivers\etc\hosts.skel"
+if not exist "%common_prefix%.skel" (
+    copy /v "%common_prefix%" "%common_prefix%.skel"
 )
 
 :UpdateHosts

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -13,16 +13,13 @@
 setlocal
 title Update Hosts
 
-set "calcs_executable=%SYSTEMROOT%\SysWOW64\cacls.exe"
-set "calcs_file=%SYSTEMROOT%\system32\config\system"
-
 :: Check if we are an administrator. If not, exit immediately.
 :: BatchGotAdmin
 :: Check for permissions
 if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
-    >nul 2>&1 "%calcs_executable%" "%calcs_file%"
+    >nul 2>&1 "%SYSTEMROOT%\SysWOW64\cacls.exe" "%SYSTEMROOT%\SysWOW64\config\system"
 ) else (
-    >nul 2>&1 "%calcs_executable%" "%calcs_file%"
+    >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 )
 
 :: Summary note

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -30,7 +30,7 @@ if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
     call :UACPrompt
 ) else (
-    goto gotAdmin
+    call :gotAdmin
 )
 
 :UACPrompt
@@ -44,24 +44,23 @@ if %ERRORLEVEL% neq 0 (
 exit /b 0
 
 :gotAdmin
-cd /d "%~dp0"
+    cd /d "%~dp0"
 
-:BackupHosts
-set "common_prefix=%WINDIR%\System32\drivers\etc\hosts"
-:: Backup the default hosts file
-if not exist "%common_prefix%.skel" (
-    copy /v "%common_prefix%" "%common_prefix%.skel"
-)
+    set "common_prefix=%WINDIR%\System32\drivers\etc\hosts"
+    :: Backup the default hosts file
+    if not exist "%common_prefix%.skel" (
+        copy /v "%common_prefix%" "%common_prefix%.skel"
+    )
 
-:UpdateHosts
-:: Update hosts file
-py updateHostsFile.py --auto --minimise %*
+    :: Update hosts file
+    py updateHostsFile.py --auto --minimise %*
 
-:: Copy over the new hosts file in-place
-copy /y /v hosts "%WINDIR%\System32\drivers\etc\"
+    :: Copy over the new hosts file in-place
+    copy /y /v hosts "%WINDIR%\System32\drivers\etc\"
 
-:: Flush the DNS cache
-ipconfig /flushdns
+    :: Flush the DNS cache
+    ipconfig /flushdns
+exit /b 0
 
 :: Summary note
 pause

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -22,11 +22,6 @@ if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
     >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 )
 
-:: Summary note
-pause
-exit /b 0
-
-
 :: If the error flag set, we do not have admin rights.
 if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
@@ -34,6 +29,8 @@ if %ERRORLEVEL% neq 0 (
 ) else (
     call :gotAdmin
 )
+
+exit /b 0
 
 :UACPrompt
     set "output_file=%TEMP%\getadmin.vbs"
@@ -62,4 +59,7 @@ exit /b 0
 
     :: Flush the DNS cache
     ipconfig /flushdns
+
+    :: Summary note
+    pause
 exit /b 0

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -10,6 +10,7 @@
 ::
 
 @echo off
+setlocal
 title Update Hosts
 
 :: Check if we are an administrator. If not, exit immediately.

--- a/updateHostsWindows.bat
+++ b/updateHostsWindows.bat
@@ -25,6 +25,11 @@ if "%PROCESSOR_ARCHITECTURE%" equ "amd64" (
     >nul 2>&1 "%calcs_executable%" "%calcs_file%"
 )
 
+:: Summary note
+pause
+exit /b 0
+
+
 :: If the error flag set, we do not have admin rights.
 if %ERRORLEVEL% neq 0 (
     echo Requesting administrative privileges...
@@ -61,6 +66,3 @@ exit /b 0
     :: Flush the DNS cache
     ipconfig /flushdns
 exit /b 0
-
-:: Summary note
-pause


### PR DESCRIPTION
- use `call :{{label}}` instead of `goto {{label}}`
- terminate all procedures with `exit /b 0`
- use variables where appropriate
- reduce spaghetti code
- existing variable names and label names were not changed

This is a first PR aiming to clean-up script related stuff.

⚠️ Please check whether scripts work yourself, edits were based on my Batch script knowledge but were not tested as I have no Windows machine. 