### PR TITLE
refresh: `stats.sh` script

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 echo > stats.out
 for TAG_DATE in $(git tag --sort=creatordate  --format='%(refname:short),%(creatordate:short)'); do
-    # echo "$TAG_DATE"
     split=(${TAG_DATE//,/ })
-    # echo ${split[0]}  
     git checkout tags/${split[0]} readmeData.json 
     entries=$(jq '.base.entries' readmeData.json)
     echo ${split[1]},${entries} >> stats.out

--- a/stats.sh
+++ b/stats.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 echo > stats.out
 for TAG_DATE in $(git tag --sort=creatordate  --format='%(refname:short),%(creatordate:short)'); do
-    split=(${TAG_DATE//,/ })
-    git checkout tags/${split[0]} readmeData.json 
-    entries=$(jq '.base.entries' readmeData.json)
-    echo ${split[1]},${entries} >> stats.out
+    IFS="," read -r -a split <<< "$TAG_DATE"
+    git checkout "tags/${split[0]}" readmeData.json 
+    entries="$(jq '.base.entries' readmeData.json)"
+    echo "${split[1]},${entries}" >> stats.out
 done

--- a/stats.sh
+++ b/stats.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo \n "" > stats.out
+echo > stats.out
 for TAG_DATE in $(git tag --sort=creatordate  --format='%(refname:short),%(creatordate:short)'); do
     # echo "$TAG_DATE"
     split=(${TAG_DATE//,/ })


### PR DESCRIPTION
- fix first command `echo`: wrong \n usage
- use `read` to put items in array instead of relying on word splitting
- quote variables where suggested by shellcheck