### PR TITLE
Fix yinzcam apps not loading

### DIFF
--- a/data/adaway.org/hosts
+++ b/data/adaway.org/hosts
@@ -11580,9 +11580,6 @@
 127.0.0.1 analytics-chi-nfl.yinzcam.com
 127.0.0.1 analytics-phi-nfl.yinzcam.com
 127.0.0.1 analytics-pit-nfl.yinzcam.com
-127.0.0.1 cards-sea-nfl.yinzcam.com
-127.0.0.1 config-sea-nfl.yinzcam.com
-127.0.0.1 resources-us.yinzcam.com
 
 # [ylx-1.com]
 127.0.0.1 ylx-1.com


### PR DESCRIPTION
I work for YinzCam. Any config, cards, or resource hosts are entirely required for app functionality.
For example, no icons will load without resources: https://resources-us.yinzcam.com/nhl/shared/logos/nhl_stl_dark.png

The cards server dictates page layout, the config server handles things like login/ticketing/etc. Those two will entirely prevent the Seahawks app from working. The resources one is preventing assets from loading in over 150 apps.

Created to fix #2248 