### PR TITLE
Add gambling and porn domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2503,3 +2503,7 @@ analytics.shein.co.uk
 0.0.0.0 cdn.cookielaw.org 
 0.0.0.0 cdn.indexww.com 
 0.0.0.0 encrypted-tbn1.gstatic.com
+
+# Added March 11, 2023
+0.0.0.0 blancoshrimp.com
+0.0.0.0 finehookupclubs.com


### PR DESCRIPTION
Hello,

These domains open automatically when watching videos on mmacore.tv:

- blancoshrimp.com: gambling.
- finehookupclubs.com: porn, example at https://finehookupclubs.com/l/25/shagslags/3b-w3mr/global/

Thank you.