### PR TITLE
add wota-tournament.com.

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2527,3 +2527,6 @@ analytics.shein.co.uk
 0.0.0.0 medium.ngtv.io
 0.0.0.0 licensing.bitmovin.c
 0.0.0.0 eq97f.publishers.tremorhub.com
+
+# Added April 13, 2023
+0.0.0.0 wota-tournament.com


### PR DESCRIPTION
A steam friend's account was compromised and sent this domain as a phishing link to try to steal steam account login information. It was under the guise of voting for a friend's team for a dota 2 tournament and requires the user to log in in order to get compromised.