### PR TITLE
Added Qualcomm tracking domain: izatcloud.net

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2545,3 +2545,4 @@ analytics.shein.co.uk
 # Added April 27, 2023
 0.0.0.0 www.gameitlive.com
 0.0.0.0 gameitlive.com
+0.0.0.0 izatcloud.net


### PR DESCRIPTION
I've added the Qualcomm tracking domain izatcloud.net as described in this article: 
https://www.nitrokey.com/news/2023/smartphones-popular-qualcomm-chip-secretly-share-private-information-us-chip-maker