### PR TITLE
Ensure that hostnames without dots are excluded.

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -842,6 +842,7 @@ class TestNormalizeRule(BaseStdout):
             "128.0.0.1",
             "0.0.0 google",
             "0.1.2.3.4 foo/bar",
+            "0.0.0.0 https"
         ]:
             self.assertEqual(normalize_rule(rule, **kwargs), (None, None))
 

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1061,7 +1061,7 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
     """
     first try: IP followed by domain
     """
-    regex = r"^\s*(\d{1,3}\.){3}\d{1,3}\s+([\w\.-]+[a-zA-Z])(.*)"
+    regex = r"^\s*(\d{1,3}\.){3}\d{1,3}\s+((?:\w+\.)+[a-zA-Z]+)(.*)"
     result = re.search(regex, rule)
 
     if result:
@@ -1090,7 +1090,7 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
     """
     # deny any potential IPv6 address here.
     if ":" not in rule:
-        regex = r"^\s*([\w\.-]+[a-zA-Z])(.*)"
+        regex = r"^\s*((?:\w+\.)+[a-zA-Z]+)(.*)"
         result = re.search(regex, rule)
 
         if result:


### PR DESCRIPTION
This patch fixes #2347.