### PR TITLE
Maintain Google Colab notebook internally

### DIFF
--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -1,0 +1,90 @@
+{
+	"cells":[
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 1: Clone last commit of StevenBlack/hosts."
+			],
+			"metadata":{"id":"step1"}
+		},
+		{
+			"cell_type":"code",
+			"source":[
+				"!git clone https://github.com/StevenBlack/hosts --depth 1"
+			],
+			"metadata":{"id":"git"}
+		},
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 2: Change directory to step into the hosts directory."],
+			"metadata":{"id":"step2"}
+		},
+		{
+			"cell_type":"code",
+			"source":[
+				"cd hosts"
+			],
+			"metadata":{"id":"cd"}
+		},
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 3: Install dependencies."
+			],
+			"metadata":{"id":"step3"}
+		},
+		{
+			"cell_type":"code",
+			"source":[
+				"!pip install --user -r requirements.txt"],
+			"metadata":{"id":"install"}
+		},
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 4: Display command-line options."
+			],
+			"metadata":{"id":"step4"}
+		},
+		{
+			"cell_type":"code",
+			"source":[
+				"!python updateHostsFile.py -h"
+			],
+			"metadata":{"id":"help"}
+		},
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 5: Generate your hosts file!\n","\n","(Edit the following command as needed)"
+			],
+			"metadata":{"id":"step5"}
+		},
+		{
+			"cell_type":"code",
+			"source":[
+				"!python updateHostsFile.py -a --compress"
+			],
+			"metadata":{"id":"generate"}
+		},
+		{
+			"cell_type":"markdown",
+			"source":[
+				"# Step 6: Download the newly generated /content/hosts/hosts file!"
+			],
+			"metadata":{"id":"download"}
+		}
+	],
+	"metadata":{
+		"kernelspec":{
+			"display_name":"Python 3",
+			"name":"python3"
+		},
+		"language_info":{
+			"name":"python"
+		}
+	},
+	"nbformat":4,
+	"nbformat_minor":0
+}

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -19,7 +19,8 @@
 			"source":[
 				"!git clone https://github.com/StevenBlack/hosts --depth 1"
 			],
-			"metadata":{"id":"git"}
+			"metadata":{"id":"git"},
+      "outputs":[]
 		},
 		{
 			"cell_type":"markdown",
@@ -32,7 +33,8 @@
 			"source":[
 				"cd hosts"
 			],
-			"metadata":{"id":"cd"}
+			"metadata":{"id":"cd"},
+      "outputs":[]
 		},
 		{
 			"cell_type":"markdown",
@@ -45,7 +47,8 @@
 			"cell_type":"code",
 			"source":[
 				"!pip install --user -r requirements.txt"],
-			"metadata":{"id":"install"}
+			"metadata":{"id":"install"},
+      "outputs":[]
 		},
 		{
 			"cell_type":"markdown",
@@ -59,7 +62,8 @@
 			"source":[
 				"!python updateHostsFile.py -h"
 			],
-			"metadata":{"id":"help"}
+			"metadata":{"id":"help"},
+      "outputs":[]
 		},
 		{
 			"cell_type":"markdown",
@@ -73,14 +77,15 @@
 			"source":[
 				"!python updateHostsFile.py -a --compress"
 			],
-			"metadata":{"id":"generate"}
+			"metadata":{"id":"generate"},
+      "outputs":[]
 		},
 		{
 			"cell_type":"markdown",
 			"source":[
 				"# Step 6: Download the newly generated /content/hosts/hosts file!"
 			],
-			"metadata":{"id":"download"}
+			"metadata":{"id":"step6"}
 		}
 	],
 	"metadata":{

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -3,7 +3,7 @@
 		{
 			"cell_type":"markdown",
 			"source":[
-				"<a href=\"https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+				"<a href=\"https://colab.research.google.com/github/StevenBlack/hosts/blob/master/hosts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
 			],
       "metadata":{"id":"colab"}
 		},

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -34,7 +34,7 @@
 			"source":[
 				"cd hosts"
 			],
-			"metadata":{"id":"cd"},,
+			"metadata":{"id":"cd"},
       "execution_count":null,
       "outputs":[]
 		},
@@ -49,7 +49,7 @@
 			"cell_type":"code",
 			"source":[
 				"!pip install --user -r requirements.txt"],
-			"metadata":{"id":"install"},,
+			"metadata":{"id":"install"},
       "execution_count":null,
       "outputs":[]
 		},
@@ -65,7 +65,7 @@
 			"source":[
 				"!python updateHostsFile.py -h"
 			],
-			"metadata":{"id":"help"},,
+			"metadata":{"id":"help"},
       "execution_count":null,
       "outputs":[]
 		},
@@ -81,7 +81,7 @@
 			"source":[
 				"!python updateHostsFile.py -a --compress"
 			],
-			"metadata":{"id":"generate"},,
+			"metadata":{"id":"generate"},
       "execution_count":null,
       "outputs":[]
 		},

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -20,6 +20,7 @@
 				"!git clone https://github.com/StevenBlack/hosts --depth 1"
 			],
 			"metadata":{"id":"git"},
+      "execution_count":null,
       "outputs":[]
 		},
 		{
@@ -33,7 +34,8 @@
 			"source":[
 				"cd hosts"
 			],
-			"metadata":{"id":"cd"},
+			"metadata":{"id":"cd"},,
+      "execution_count":null,
       "outputs":[]
 		},
 		{
@@ -47,7 +49,8 @@
 			"cell_type":"code",
 			"source":[
 				"!pip install --user -r requirements.txt"],
-			"metadata":{"id":"install"},
+			"metadata":{"id":"install"},,
+      "execution_count":null,
       "outputs":[]
 		},
 		{
@@ -62,7 +65,8 @@
 			"source":[
 				"!python updateHostsFile.py -h"
 			],
-			"metadata":{"id":"help"},
+			"metadata":{"id":"help"},,
+      "execution_count":null,
       "outputs":[]
 		},
 		{
@@ -77,7 +81,8 @@
 			"source":[
 				"!python updateHostsFile.py -a --compress"
 			],
-			"metadata":{"id":"generate"},
+			"metadata":{"id":"generate"},,
+      "execution_count":null,
       "outputs":[]
 		},
 		{

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -3,7 +3,7 @@
 		{
 			"cell_type":"markdown",
 			"source":[
-				"<a href=\"https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+				"<a href=\"https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
 			],
       "metadata":{"id":"colab"}
 		},

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -1,6 +1,12 @@
 {
 	"cells":[
 		{
+			"cell_type": "markdown",
+			"source": [
+				"<a href=\"https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+			]
+		},
+		{
 			"cell_type":"markdown",
 			"source":[
 				"# Step 1: Clone last commit of StevenBlack/hosts."

--- a/hosts.ipynb
+++ b/hosts.ipynb
@@ -1,10 +1,11 @@
 {
 	"cells":[
 		{
-			"cell_type": "markdown",
-			"source": [
+			"cell_type":"markdown",
+			"source":[
 				"<a href=\"https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-			]
+			],
+      "metadata":{"id":"colab"}
 		},
 		{
 			"cell_type":"markdown",

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts/hosts.ipynb) environment.
+Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb) environment.
 
 ### Common steps regardless of your development environment
 

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-Spin up a free remote [Google Colab](https://colab.research.google.com/drive/1tYWXpU2iuPDqN_o03JW9ml3ExO80eBLq?usp=sharing) environment.
+Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts.ipynb) environment.
 
 ### Common steps regardless of your development environment
 

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/StevenBlack/hosts/blob/master/hosts.ipynb)
 
 ### Common steps regardless of your development environment
 

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts.ipynb) environment.
+Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts/hosts.ipynb) environment.
 
 ### Common steps regardless of your development environment
 

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-Spin up a free remote [Google Colab](https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb) environment.
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ScriptTiger/hosts/blob/master/hosts.ipynb)
 
 ### Common steps regardless of your development environment
 

--- a/readme_template.md
+++ b/readme_template.md
@@ -152,7 +152,7 @@ at the user level. More information about it can be found on pip
 
 ### Option 4: Generate it in Google Colab
 
-Spin up a free remote [Google Colab](https://colab.research.google.com/drive/1tYWXpU2iuPDqN_o03JW9ml3ExO80eBLq?usp=sharing) environment.
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/StevenBlack/hosts/blob/master/hosts.ipynb)
 
 ### Common steps regardless of your development environment
 


### PR DESCRIPTION
Right now, I'm currently maintaining the notebook on my Google Drive. This update just brings the notebook into the hosts repository so it can be maintained internally. This is simply to drop the third party (myself), and this should not bring any additional burden (of significance) to the maintenance of the repository in general.

To view the intended outcome of this update, please refer to the following commit:
https://github.com/ScriptTiger/hosts/tree/1cae8718f56f45661d0103847f7c291ef0fdd5e7

As this update includes links to the StevenBlack/hosts repository which will only exist after the update is applied, using a previous commit which includes links to the ScriptTiger/hosts repository is needed since those links already exist and can be tested now.

Features:
By opening the hosts.ipynb from the GitHub repository, GitHub recognizes the format and displays it appropriately.
By clicking the "open in colab" link from either the notebook itself or README, the notebook is directly opened by Google Colab without a third-party owner/host.
Issues related specifically to the notebook can be triaged internally by the maintainers of the hosts repository, as well as keeping full transparency of the notebook internal to the repository.