### PR TITLE
flake: rm flake-utils dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,45 +1,59 @@
 {
   description = "Unified hosts file with base extensions.";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils }: {
-    nixosModule = { config, ... }:
-      with nixpkgs.lib;
-      let
-        cfg = config.networking.stevenBlackHosts;
-        alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
-                         (if cfg.blockGambling then [ "gambling" ] else []) ++
-                         (if cfg.blockPorn then [ "porn" ] else []) ++
-                         (if cfg.blockSocial then [ "social" ] else []);
-        alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
-      in
-      {
-        options.networking.stevenBlackHosts = {
-          enable = mkEnableOption "Use Steven Black's hosts file as extra hosts.";
-          blockFakenews = mkEnableOption "Additionally block fakenews hosts.";
-          blockGambling = mkEnableOption "Additionally block gambling hosts.";
-          blockPorn = mkEnableOption "Additionally block porn hosts.";
-          blockSocial = mkEnableOption "Additionally block social hosts.";
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      # Python-supported systems
+      supportedSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+      });
+    in
+    {
+      nixosModule = { config, ... }:
+        with nixpkgs.lib;
+        let
+          cfg = config.networking.stevenBlackHosts;
+          alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
+                           (if cfg.blockGambling then [ "gambling" ] else []) ++
+                           (if cfg.blockPorn then [ "porn" ] else []) ++
+                           (if cfg.blockSocial then [ "social" ] else []);
+          alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
+        in
+        {
+          options.networking.stevenBlackHosts = {
+            enable = mkEnableOption "Use Steven Black's hosts file as extra hosts.";
+            blockFakenews = mkEnableOption "Additionally block fakenews hosts.";
+            blockGambling = mkEnableOption "Additionally block gambling hosts.";
+            blockPorn = mkEnableOption "Additionally block porn hosts.";
+            blockSocial = mkEnableOption "Additionally block social hosts.";
+          };
+          config = mkIf cfg.enable {
+            networking.extraHosts =
+              builtins.readFile (
+                "${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts"
+              );
+          };
         };
-        config = mkIf cfg.enable {
-          networking.extraHosts =
-            builtins.readFile (
-              "${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts"
-            );
-        };
-      };
-  } // flake-utils.lib.eachDefaultSystem
-    (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            python3
-            python3Packages.flake8
-            python3Packages.requests
-          ];
-        };
-      }
-    );
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system}; in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              python3
+              python3Packages.flake8
+              python3Packages.requests
+            ];
+          };
+        });
+    };
 }


### PR DESCRIPTION
Pulling in an entire dependency to call a for-loop is wasteful & largely useless.

When user adds this module to their config, flake-utils & all of its subdependencies will be pulled into the user’s flake.lock file. This for-loop was only being used for the developer shell to which a lot of folks probably aren’t doing active developments in this project as the module itself doesn’t require it. Potentially damagingly is that this project lacks its own flake.lock so the latest flake-utils will always be downloaded regardless of if it that version is compatible or not. Additionally, flake-utils’ default system list doesn’t include i686-linux which upstream Python3 in Nixpkgs does.

The alternative solution to these problems is to remove the dependency & just write a for-loop in this project. This solution could be more or less robust, but it is an extensible version of that loop that could handle overlays or config changes if needed in the future.

(the diff looks bigger than it really is because of the module block needed to be indented for the new `let` block; a reviewer can look at the [whitespace-free diff](https://github.com/StevenBlack/hosts/pull/2421/files?diff=unified&w=1))