### PR TITLE
flake: rm `numtide/flake-utils` dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,45 +1,50 @@
 {
   description = "Unified hosts file with base extensions.";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils }: {
-    nixosModule = { config, ... }:
-      with nixpkgs.lib;
-      let
-        cfg = config.networking.stevenBlackHosts;
-        alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
-                         (if cfg.blockGambling then [ "gambling" ] else []) ++
-                         (if cfg.blockPorn then [ "porn" ] else []) ++
-                         (if cfg.blockSocial then [ "social" ] else []);
-        alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
-      in
-      {
-        options.networking.stevenBlackHosts = {
-          enable = mkEnableOption "Use Steven Black's hosts file as extra hosts.";
-          blockFakenews = mkEnableOption "Additionally block fakenews hosts.";
-          blockGambling = mkEnableOption "Additionally block gambling hosts.";
-          blockPorn = mkEnableOption "Additionally block porn hosts.";
-          blockSocial = mkEnableOption "Additionally block social hosts.";
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.unix;
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+      });
+    in
+    {
+      nixosModule = { config, ... }:
+        with nixpkgs.lib;
+        let
+          cfg = config.networking.stevenBlackHosts;
+          alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
+                           (if cfg.blockGambling then [ "gambling" ] else []) ++
+                           (if cfg.blockPorn then [ "porn" ] else []) ++
+                           (if cfg.blockSocial then [ "social" ] else []);
+          alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
+        in
+        {
+          options.networking.stevenBlackHosts = {
+            enable = mkEnableOption "Use Steven Black's hosts file as extra hosts.";
+            blockFakenews = mkEnableOption "Additionally block fakenews hosts.";
+            blockGambling = mkEnableOption "Additionally block gambling hosts.";
+            blockPorn = mkEnableOption "Additionally block porn hosts.";
+            blockSocial = mkEnableOption "Additionally block social hosts.";
+          };
+          config = mkIf cfg.enable {
+            networking.extraHosts =
+              builtins.readFile (
+                "${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts"
+              );
+          };
         };
-        config = mkIf cfg.enable {
-          networking.extraHosts =
-            builtins.readFile (
-              "${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts"
-            );
-        };
-      };
-  } // flake-utils.lib.eachDefaultSystem
-    (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            python3
-            python3Packages.flake8
-            python3Packages.requests
-          ];
-        };
-      }
-    );
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system}; in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              python3
+              python3Packages.flake8
+              python3Packages.requests
+            ];
+          };
+        });
+    };
 }


### PR DESCRIPTION
The previous merge request, #2421, was closed in haste. The [original Nix Flake contributor, @Deleh, confirmed](https://github.com/StevenBlack/hosts/pull/2421#issuecomment-1696717703), that this does not remove the Nix Flake, nor does it change any of the module logic or buildInputs or the devShell. What this *does* is remove the reliance on the `numtide/flake-utils` dependency.

Please confirm with the [whitespace-hidden diff](https://github.com/StevenBlack/hosts/pull/2425/files?diff=unified&w=1) that nothing fundamental is changed.

---

Original message:

Pulling in an entire dependency to call a for-loop is wasteful & largely useless.

When user adds this module to their config, flake-utils & all of its subdependencies will be pulled into the user’s flake.lock file. This for-loop was only being used for the developer shell to which a lot of folks probably aren’t doing active developments in this project as the module itself doesn’t require it. Potentially damagingly is that this project lacks its own flake.lock so the latest flake-utils will always be downloaded regardless of if it that version is compatible or not. Additionally, flake-utils’ default system list doesn’t include i686-linux which upstream Python3 in Nixpkgs does.

The alternative solution to these problems is to remove the dependency & just write a for-loop in this project. This solution could be more or less robust, but it is an extensible version of that loop that could handle overlays or config changes if needed in the future.