### PR TITLE
Correct 2nd Iter: Hostnames to lowercase.

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -854,6 +854,25 @@ class TestNormalizeRule(BaseStdout):
             expected = "==>" + rule + "<=="
             self.assertIn(expected, output)
 
+    def test_mixed_cases(self):
+        for rule, expected_target in (
+            ("tWiTTer.cOM", "twitter.com"),
+            ("goOgLe.Com", "google.com"),
+            ("FoO.bAR.edu", "foo.bar.edu"),
+        ):
+            expected = (expected_target, "0.0.0.0 " + expected_target + "\n")
+
+            actual = normalize_rule(
+                rule, target_ip="0.0.0.0", keep_domain_comments=False
+            )
+            self.assertEqual(actual, expected)
+
+            # Nothing gets printed if there's a match.
+            output = sys.stdout.getvalue()
+            self.assertEqual(output, "")
+
+            sys.stdout = StringIO()
+
     def test_no_comments(self):
         for target_ip in ("0.0.0.0", "127.0.0.1", "8.8.8.8"):
             rule = "127.0.0.1 1.google.com foo"

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1123,6 +1123,8 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
             # Example: 0.0.0.0 example.org
             hostname, suffix = split_rule[-1], None
 
+        hostname = hostname.lower()
+
         if (
             is_ip(hostname)
             or re.search(static_ip_regex, hostname)
@@ -1153,6 +1155,8 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
             hostname, suffix = split_rule
         except ValueError:
             hostname, suffix = split_rule[0], None
+
+        hostname = hostname.lower()
 
         return normalize_response(hostname, suffix)
 


### PR DESCRIPTION
As mentioned by @StevenBlack in #2400, hostnames should be converted to lowercase.