### PR TITLE
Correct 2nd Iter: Ignore subject with slashes (/).

### DIFF
--- a/testUpdateHostsFile.py
+++ b/testUpdateHostsFile.py
@@ -843,6 +843,7 @@ class TestNormalizeRule(BaseStdout):
             "::1",
             "0.0.0.0 128.0.0.2",
             "0.1.2.3 foo/bar",
+            "0.3.4.5 example.org/hello/world",
             "0.0.0.0 https",
             "0.0.0.0 https..",
         ]:

--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1129,6 +1129,7 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
             is_ip(hostname)
             or re.search(static_ip_regex, hostname)
             or "." not in hostname
+            or "/" in hostname
             or ".." in hostname
             or ":" in hostname
         ):
@@ -1147,6 +1148,7 @@ def normalize_rule(rule, target_ip, keep_domain_comments):
         not re.search(static_ip_regex, split_rule[0])
         and ":" not in split_rule[0]
         and ".." not in split_rule[0]
+        and "/" not in split_rule[0]
         and "." in split_rule[0]
     ):
         # Deny anything that looks like an IP; doesn't container dots or INVALID.


### PR DESCRIPTION
Upon checking the latest release after merging #2433, I noticed that some subjects with slashes go/went through.

This patch fixes that by ignoring subjects that contain slashes.