### PR TITLE
Added information about Hosts Compress Windows to the README; this to…

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -453,7 +453,7 @@ the
 [the comments within the `cmd` file](https://github.com/StevenBlack/hosts/blob/master/disable-dnscache-service-win.bat)
 for more details.
 
-Disabling the DNS Cache Service can cause issues with services and applications like *WSL* and it's possible to compress the hosts file and negate the need to disable the DNS caching service. You can try the PowerShell compression script and check out the guide located at the [Hosts Compression Scripts repository](https://github.com/Lateralus138/hosts-compression-scripts).
+Disabling the DNS Cache Service can cause issues with services and applications like *WSL* and it's possible to compress the hosts file and negate the need to disable the DNS caching service. You can try the *C++* Windows command line tool at [Hosts Compress - Windows](https://github.com/Lateralus138/hosts-compress-windows) (the recommended method) or the *PowerShell* compression script and check out the guide located at the [Hosts Compression Scripts](https://github.com/Lateralus138/hosts-compression-scripts) repository.
 
 ## Reloading hosts file
 
@@ -614,6 +614,7 @@ devices under a variety of operating systems.
   This is a cross-platform command line utility to help install/update hosts
   files found at this repository.
 - [Hosts Compression Scripts](https://github.com/Lateralus138/hosts-compression-scripts) These are various scripts to help compress hosts files (by the author of BlackHosts).
+- [Hosts Compress - Windows](https://github.com/Lateralus138/hosts-compress-windows) This is a *C++* Windows command line tool to help compress hosts files (by the author of BlackHosts and Hosts Compression Scripts). This is highly recommended over the scripts as it is **exponentially faster**.
 - [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Combining-Blocklists)
   provides a tool to build block lists from local and remote lists in common
   formats.


### PR DESCRIPTION
…ol is recommended over the previous scripts. - 09/13/2023 20:02:32 UTC

I considered removing the Hosts Compression Scripts link, but I think it should stay just in case someone prefers the (much slower) script for whatever reason. I will be adding a Linux C++ version soon. I've decided to separate the Windows and Linux versions unlike some of my other tools.

Thanks for any consideration of this addition.