### PR TITLE
Remove `licensing.bitmovin.com` (neither ads nor tracker)

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2518,7 +2518,6 @@
 # Added April 7, 2023
 0.0.0.0 d2uap9jskdzp2.cloudfront.net
 0.0.0.0 steadfastseat.com
-0.0.0.0 licensing.bitmovin.com
 0.0.0.0 eq97f.publishers.tremorhub.com
 
 # Added April 13, 2023


### PR DESCRIPTION
Hi,

I'm writing on behalf of [Bitmovin](https://github.com/bitmovin) to inquire about the possibility of removing `licensing.bitmovin.com` from your list.

It is not in any way an ads or tracking url (ie. we do none of tracking, monitoring, UA/IP/Geo checks, browser detection, analytics, telemetry, linking to third-partys, pixels, referrers, fingerprinting, event/perf logging...), but simply allows us to charge our corporate customers for their usage of our products. Blocking our license counting is costing Bitmovin money at no benefit to Pi-hole users, and may force Bitmovin to move to a more complex off-by-default model, which would cause playback breakage on Pi-hole enjoyers.

Feel free to get in touch with Bitmovin directly around this issue.

Best regards,
Kevin Rocard