### PR TITLE
CI: remove Python 3.7, add Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,15 @@ jobs:
           - '3.12'
         os:
           - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: macos-latest
+            python: '3.8'
+          - os: macos-latest
+            python: '3.12'
+          - os: windows-latest
+            python: '3.8'
+          - os: windows-latest
+            python: '3.12'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         os:
           - ubuntu-latest
           - macos-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests ~=2.20
-flake8 ~=4.0
+flake8 ~=6.0


### PR DESCRIPTION
I dropped Python 3.7 from CI because then the CI matrix would be 6x3 = 18 jobs, plus it's EOL.

Alternatively, we could run specific versions on macOS and Windows, like the oldest and latest supported ones), in order to reduce the CI matrix and time.

Let me know what you prefer.

EDIT:

- I went with the explicit macOS and Windows versions
- I had to update flake8 to the latest version so that it works with Python 3.12. The latest flake8 version (6.0) also requires Python >= 3.8.
- There's a Python 3.12 warning when running `updateHostsFile.py`:
  `/home/runner/work/hosts/hosts/updateHostsFile.py:1386: SyntaxWarning: invalid escape sequence '\W'`.
  It probably comes from the comment: https://github.com/StevenBlack/hosts/blob/4ee89fc68a7cd71b4def49d5f215e58ad3fae033/updateHostsFile.py#L1389-L1390
  Unsure if we can do something about it.

/CC @StevenBlack @funilrys 