### PR TITLE
Added rtnl.bxcl.de

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2687,3 +2687,6 @@
 # Added December 17, 2023
 0.0.0.0 co.vaicore.site
 0.0.0.0 int.vaicore.site
+
+# Added December 28, 2023
+0.0.0.0 rtnl.bxcl.de


### PR DESCRIPTION
TonieBox "Telemetry"

Thanks to great people at [toniebox-reverse-engineering](https://toniebox-reverse-engineering.github.io/docs/wiki/general/protocol-analysis/#rtnlbxclde) it should be a good idea to block rtnl.bxcl.de.

As answered [here](https://media.ccc.de/v/37c3-11993-toniebox_reverse_engineering#t=3141) you can block it without side effect.