### PR TITLE
Remove rtnl.bxcl.de

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2687,9 +2687,6 @@
 0.0.0.0 co.vaicore.site
 0.0.0.0 int.vaicore.site
 
-# Added December 28, 2023
-0.0.0.0 rtnl.bxcl.de
-
 # Added February 11, 2024
 0.0.0.0 product-cdn.liftoff-creatives.io
 0.0.0.0 preview.liftoff-creatives.io


### PR DESCRIPTION
This is the host for toniebox, a kids toy. 