### PR TITLE
updateHostsFile.py: use a raw string for comment

### DIFF
--- a/updateHostsFile.py
+++ b/updateHostsFile.py
@@ -1383,7 +1383,7 @@ def update_readme_data(readme_file, **readme_updates):
 
 
 def move_hosts_file_into_place(final_file):
-    """
+    r"""
     Move the newly-created hosts file into its correct location on the OS.
 
     For UNIX systems, the hosts file is "etc/hosts." On Windows, it's


### PR DESCRIPTION
This fixes a SyntaxWarning with Python 3.12:

```
 /home/runner/work/hosts/hosts/updateHostsFile.py:1386: SyntaxWarning: invalid escape sequence '\W'
  """
```