### PR TITLE
sadostic.pl

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2740,3 +2740,7 @@
 
 # Added April 13, 2024
 0.0.0.0 alertcibcsecuremobile.com
+
+# Added April 24, 2024
+0.0.0.0 sadostic.pl
+0.0.0.0 www.sadostic.pl


### PR DESCRIPTION
Original, good, valid domain is `sadistic.pl`
I made typo i > o and weird ads redirect shows. 

