### PR TITLE
ejuiashsateam.info

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2744,3 +2744,7 @@
 # Added April 24, 2024
 0.0.0.0 sadostic.pl
 0.0.0.0 www.sadostic.pl
+
+# Added April 28, 2024
+0.0.0.0 ejuiashsateam.info
+0.0.0.0 www.ejuiashsateam.info


### PR DESCRIPTION
JS/Adware.Atocari.A blocked by ESET
https://whois.domaintools.com/ejuiashsateam.info
```
Created on 2024-03-31
Expires on 2025-03-31
Updated on 2024-04-05
```
![20240428-1714327745](https://github.com/hagezi/dns-blocklists/assets/9846948/4aab69fe-578c-4eb3-b232-a8bf39259032)
