### PR TITLE
Add netflix log host

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2755,3 +2755,6 @@
 
 # Added May 19, 2024
 0.0.0.0 urdxh.com
+
+# Added May 30, 2024
+0.0.0.0 logs.netflix.com


### PR DESCRIPTION
This PR adds the logs.netflix.com host, which appears to be some sort of tracker.

I've tested the netflix app on webOS and on a normal browser and it works fine with this host blocked.