### PR TITLE
Update hosts to remove ECBSN , for rakuten

### DIFF
--- a/data/adaway.org/hosts
+++ b/data/adaway.org/hosts
@@ -4172,12 +4172,6 @@
 # [ebz.io]
 127.0.0.1 ebz.io
 
-# [ecbsn.com]
-127.0.0.1 apituner.ecbsn.com
-127.0.0.1 api.engager.ecbsn.com
-127.0.0.1 events.engager.ecbsn.com
-127.0.0.1 ffconf.ecbsn.com
-
 # [ecorebates.com]
 127.0.0.1 static.ecorebates.com
 


### PR DESCRIPTION
As per issue
https://github.com/StevenBlack/hosts/issues/2670