### PR TITLE
changed url in nix flake from literal to string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -434,7 +434,7 @@ like this:
 
 ```nix
 {
-  inputs.hosts.url = github:StevenBlack/hosts;
+  inputs.hosts.url = "github:StevenBlack/hosts";
   outputs = { self, nixpkgs, hosts }: {
     nixosConfigurations.my-hostname = {
       system = "<architecture>";


### PR DESCRIPTION
URL literal for nix flake inputs are deprecated