### PR TITLE
Add malicious Polyfill.io domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2761,3 +2761,8 @@
 
 # Added June 26, 2024
 0.0.0.0 mailsupport-24f7f1500ed129bc71f2ad9c06fe1e73.pages.dev
+
+# Added June 27, 2024
+0.0.0.0 polyfill.io
+0.0.0.0 cdn.polyfill.io
+0.0.0.0 googie-anaiytics.com


### PR DESCRIPTION
Pollyfill [dot] io was sold to a Chinese company who is now using it maliciously.

[Cloudflare Blog](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet)