### PR TITLE
removed trailing dot

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2777,7 +2777,7 @@
 0.0.0.0 tracker.nitropay.com
 
 # Added August 30, 2024
-0.0.0.0 grid-bidder.criteo.
+0.0.0.0 grid-bidder.criteo
 0.0.0.0 a-ring.msedge.net
 0.0.0.0 k-ring.msedge.net
 0.0.0.0 hb.yellowblue.io

--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2783,3 +2783,4 @@
 0.0.0.0 hb.yellowblue.io
 0.0.0.0 gtrack.kueezrtb.com
 0.0.0.0 hb-api.omnitagjs.com
+


### PR DESCRIPTION
grid-bidder.criteo. has a trailing period, while no other domain does