### PR TITLE
remove cdn.cookielaw.com

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2495,7 +2495,6 @@
 
 # Added March 7, 2023
 0.0.0.0 a125375509.cdn.optimizely.com
-0.0.0.0 cdn.cookielaw.org
 0.0.0.0 cdn.indexww.com
 
 # Added March 25, 2023


### PR DESCRIPTION
This breaks multiple sites, most importantly certain subpages of SoundCloud when logged in (notifications, settings, ...).

This is the loader CDN for a cookie-banner.
It is in my opinion none of the following:
- adware
- malware
- fakenews
- gambling
- porn
- social

While the cookie banners certainly can be classified as `annoyances`, this list does not seem to be about annoyances.