### PR TITLE
Add Fruit Merge (Android) hosts

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -2960,3 +2960,24 @@
 0.0.0.0 t-in.ads.heytapmobile.com
 0.0.0.0 uapi.ads.heytapmobi.com
 0.0.0.0 wifi.ads.oppomobile.com
+
+0.0.0.0 ts.amazon-adsystem.com
+0.0.0.0 tracker.zmaticoo.com
+0.0.0.0 i-adq.mediation.unity3d.com
+0.0.0.0 i-sdk.mediation.unity3d.com
+0.0.0.0 cdn.iads.unity3d.com
+0.0.0.0 a-iad3.1rx.io
+0.0.0.0 cdn.zmaticoo.com
+0.0.0.0 o209266.ingest.us.sentry.io
+0.0.0.0 zmaticoo.funsdata.com
+0.0.0.0 sdk-api.maticooads.com
+0.0.0.0 sts.applovin.com
+0.0.0.0 check-tcp.rayjump.com
+0.0.0.0 configure-tcp.rayjump.com
+0.0.0.0 lazy-tcp.rayjump.com
+0.0.0.0 policy-tcp.rayjump.com
+0.0.0.0 observe-tcp.mtgglobals.com
+0.0.0.0 configure-tcp-android.mtgglobals.com
+0.0.0.0 cdn-adn-https.mtgglobals.com
+0.0.0.0 hybird.mtgglobals.com
+0.0.0.0 api.revenuads.com


### PR DESCRIPTION
Add some (sub)domains for ads and trackers used by the Fruit Merge game
for Android.