### PR TITLE
Nix allow appending config + refactor

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,32 +10,33 @@
     in
     {
       nixosModule = { config, ... }:
-        with nixpkgs.lib;
         let
+          inherit (nixpkgs) lib;
           cfg = config.networking.stevenBlackHosts;
-          alternatesList = (if cfg.blockFakenews then [ "fakenews" ] else []) ++
-                           (if cfg.blockGambling then [ "gambling" ] else []) ++
-                           (if cfg.blockPorn then [ "porn" ] else []) ++
-                           (if cfg.blockSocial then [ "social" ] else []);
+          alternatesList =
+            (lib.optional cfg.blockFakenews "fakenews")
+            ++ (lib.optional cfg.blockGambling "gambling")
+            ++ (lib.optional cfg.blockPorn "porn")
+            ++ (lib.optional cfg.blockSocial "social");
           alternatesPath = "alternates/" + builtins.concatStringsSep "-" alternatesList + "/";
         in
         {
           options.networking.stevenBlackHosts = {
-            enable = mkEnableOption "Steven Black's hosts file";
-            enableIPv6 = mkEnableOption "IPv6 rules" // {
+            enable = lib.mkEnableOption "Steven Black's hosts file";
+            enableIPv6 = lib.mkEnableOption "IPv6 rules" // {
               default = config.networking.enableIPv6;
             };
-            blockFakenews = mkEnableOption "fakenews hosts entries";
-            blockGambling = mkEnableOption "gambling hosts entries";
-            blockPorn = mkEnableOption "porn hosts entries";
-            blockSocial = mkEnableOption "social hosts entries";
+            blockFakenews = lib.mkEnableOption "fakenews hosts entries";
+            blockGambling = lib.mkEnableOption "gambling hosts entries";
+            blockPorn = lib.mkEnableOption "porn hosts entries";
+            blockSocial = lib.mkEnableOption "social hosts entries";
           };
-          config = mkIf cfg.enable {
+          config = lib.mkIf cfg.enable {
             networking.extraHosts =
               let
-                orig = builtins.readFile ("${self}/" + (if alternatesList != [] then alternatesPath else "") + "hosts");
+                orig = builtins.readFile ("${self}/" + (lib.optionalString (alternatesList != []) alternatesPath) + "hosts");
                 ipv6 = builtins.replaceStrings [ "0.0.0.0" ] [ "::" ] orig;
-              in orig + (optionalString cfg.enableIPv6 ("\n" + ipv6));
+              in lib.mkAfter (orig + (lib.optionalString cfg.enableIPv6 ("\n" + ipv6)));
           };
         };
 

--- a/readme.md
+++ b/readme.md
@@ -433,7 +433,14 @@ like this:
 
 ```nix
 {
-  inputs.hosts.url = "github:StevenBlack/hosts";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=$YOUR-VERSION";
+    hosts = {
+      url = "github:StevenBlack/hosts";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
   outputs = { self, nixpkgs, hosts }: {
     nixosConfigurations.my-hostname = {
       system = "<architecture>";


### PR DESCRIPTION
The motivation for refactor is wanting to still add my own values to the list such as

```
127.0.0.1 myproject.localhost
```

At present enabling will override existing configurations. This should fix that as well as other minor fixups along the way. Now with this config

```nix
{
   networking = {
      stevenBlockHosts = {
         enable = true;
         blockFakenews = true;
      };
      extraHosts = ''
         127.0.0.1 myproject.localhost
      '';
   };
}
```

And the `lib.mkAfter` will append the StevenBlack `hosts` list after my extra config.

```
127.0.0.1 localhost
::1 localhost

127.0.0.1 myproject.localhost

# Title: StevenBlack/hosts with the fakenews extension
#
# …rest of config
```

The docs were also updated to including following the user’s existing `nixpkgs` since this is probably what the user wants (not adding multiple copies of the expensive-to-download `nixpkgs` tarball).

Can review commit by commit.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.