### PR TITLE
docs: add more depth to Flake input

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -386,7 +386,14 @@ like this:
 
 ```nix
 {
-  inputs.hosts.url = "github:StevenBlack/hosts";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=$YOUR-REF";
+    hosts = {
+      url = "github:StevenBlack/hosts"; # or a fork/mirror
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
   outputs = { self, nixpkgs, hosts }: {
     nixosConfigurations.my-hostname = {
       system = "<architecture>";


### PR DESCRIPTION
At present, if a user copy-pastes the current documentation, a version of Nixpkgs will be added to their `flake.lock` lockfile. This is probably not what the user wants as Nixpkgs, the tarball, is quite large & the user likely expects the StevenBlack Flake to be used as a module to just be using the Nixpkgs of the system.

This change should also help new Nix users know how to pin a Nix version if there ever comes a time where the Nix API changes—even if `lib` tries to be stable & backwards-compatible.

Additionally, provide a comment about where & what the input can be—such as a mirror or a local fork for development.

---

Also has been open @ https://gitlab.com/StevenBlack/hosts/-/merge_requests/1