### PR TITLE
nix flake: use `lib.mkAfter` put the host list at the end

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
                 orig = builtins.readFile ("${self}/" + (lib.optionalString (alternatesList != []) alternatesPath) + "hosts");
                 ipv6 = builtins.replaceStrings [ "0.0.0.0" ] [ "::" ] orig;
               in
-              orig + (lib.optionalString cfg.enableIPv6 ("\n" + ipv6));
+              lib.mkAfter (orig + (lib.optionalString cfg.enableIPv6 ("\n" + ipv6)));
           };
         };
 


### PR DESCRIPTION
At present, if a user uses `networking.stevenBlockHosts.enable = true` in tandem with `networking.extraHosts`, the `extraHosts` will put be put after which makes it very difficult to see the custom adds with even the `$PAGER` operating a bit slow due to file size. I would propose putting this project’s hosts at the end of the hosts file. Meaning:

```nix
{
  networking = {
    stevenBlockHosts.enable = true;
    extraHosts = ''
      127.0.0.1 myproject.localhost
    '';
  };
}
```

will now output

```
127.0.0.1 localhost
::1 localhost

127.0.0.1 myproject.localhost

# Title: StevenBlack/hosts with the fakenews extension
#
# …
```

NOTE: using `lib.*` like #2813  to avoid a potential merge conflict

---

Also has been open @ https://gitlab.com/StevenBlack/hosts/-/merge_requests/3