### PR TITLE
Generate unbound configuration files from blocklist files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
           dir = ./alternates;
           lists =
             pkgs.lib.trivial.pipe (builtins.readDir ./alternates) [
-              (pkgs.lib.attrsets.filterAttrs (k: v: v == "directory"))
+              (pkgs.lib.filterAttrs (k: v: (builtins.length (pkgs.lib.strings.splitString "-" k)) == 1 && v == "directory")) # select only non-combined filter lists
               (pkgs.lib.attrsets.mapAttrs (k: v: dir + "/${k}/hosts"))
               (pkgs.lib.attrsets.filterAttrs (k: v: builtins.pathExists v))
             ]

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,25 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs {
         inherit system;
       });
+
+      toUnboundConf = (
+        file:
+        nixpkgs.lib.strings.concatMapStringsSep "\n" (
+            line:
+            if (nixpkgs.lib.strings.hasPrefix "#" line) || (line == "") then
+              line
+            else
+              let
+                split_line = (nixpkgs.lib.strings.splitString " " line);
+                address = builtins.elemAt split_line 0;
+                domain = builtins.elemAt split_line 1;
+              in
+              ''
+                local-zone: "${domain}" redirect
+                local-data: "${domain} A ${address}"
+              ''
+          ) (nixpkgs.lib.strings.splitString "\n" (builtins.readFile file))
+      );
     in
     {
       nixosModule = { config, ... }:
@@ -50,5 +69,35 @@
             ];
           };
         });
+
+      overlays.default = (
+        final: prev: {
+          unboundconfs = prev.lib.makeScope prev.pkgs.newScope (newscope: self.packages.${prev.system});
+        }
+      );
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+          dir = ./alternates;
+          lists =
+            pkgs.lib.trivial.pipe (builtins.readDir ./alternates) [
+              (pkgs.lib.attrsets.filterAttrs (k: v: v == "directory"))
+              (pkgs.lib.attrsets.mapAttrs (k: v: dir + "/${k}/hosts"))
+              (pkgs.lib.attrsets.filterAttrs (k: v: builtins.pathExists v))
+            ]
+            // {
+              all = ./hosts;
+            };
+        in
+        pkgs.lib.attrsets.mapAttrs (
+          k: v:
+          pkgs.writeTextFile {
+            name = k;
+            text = toUnboundConf v;
+          }
+        ) lists
+      );
     };
 }


### PR DESCRIPTION
* Generate unbound.conf files from each hosts file in repository
* Add an overlay exposing the confs files under unboundconfs nested scope
* Unbound users consuming the flake are now able to import the blocklists via config similar to this:
```
{pkgs, ...}:
{
  services.unbound = {
    enable = true;
    settings = {
      include = [
        pkgs.unboundconfs.fakenews-gambling-porn
      ];
    };
  };
}
```