### PR TITLE
Use mkOption when setting enableIPv6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,11 @@
         {
           options.networking.stevenBlackHosts = {
             enable = mkEnableOption "Steven Black's hosts file";
-            enableIPv6 = mkEnableOption "IPv6 rules" // {
+            enableIPv6 = mkOption {
+              type = types.bool;
               default = config.networking.enableIPv6;
+              defaultText = "`config.networking.enableIPv6`";
+              description = "Whether to enable IPv6 rules.";
             };
             blockFakenews = mkEnableOption "fakenews hosts entries";
             blockGambling = mkEnableOption "gambling hosts entries";


### PR DESCRIPTION
As discovered in https://github.com/StevenBlack/hosts/issues/2828, using `documentation.nixos.includeAllModules` in combination with the change to introduce the `enableIPv6` option (https://github.com/StevenBlack/hosts/pull/2803) caused nix to fail to evaluate the default option.

Using `mkOption` in place of `mkEnableOption` when overriding the default based on a system wide configration, resolves the issue.

Fixes https://github.com/StevenBlack/hosts/issues/2828.