### PR TITLE
Add ad domains of various services

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -3025,3 +3025,18 @@
 
 # Added May 8, 2025
 0.0.0.0 clientennota-webnl.ddns.info
+
+# Added June 25, 2025
+0.0.0.0 afs.googlesyndication.com
+0.0.0.0 analyticsengine.s3.amazonaws.com
+0.0.0.0 analytics.s3.amazonaws.com
+0.0.0.0 mediavisor.doubleclick.net
+0.0.0.0 adm.hotjar.com
+0.0.0.0 ads-api.tiktok.com
+0.0.0.0 ads-sg.tiktok.com
+0.0.0.0 analytics-sg.tiktok.com
+0.0.0.0 adtech.yahooinc.com
+0.0.0.0 adfstat.yandex.ru
+0.0.0.0 adfox.yandex.ru
+0.0.0.0 bdapi-ads.realmemobile.com
+0.0.0.0 bdapi-in-ads.realmemobile.com


### PR DESCRIPTION
Added domains of advertisement and analytics services, specifically:

- `afs.googlesyndication.com`
- `analyticsengine.s3.amazonaws.com`
- `analytics.s3.amazonaws.com`
- `mediavisor.doubleclick.net`
- `adm.hotjar.com`
- `ads-api.tiktok.com`
- `ads-sg.tiktok.com`
- `analytics-sg.tiktok.com`
- `adtech.yahooinc.com`
- `adfstat.yandex.ru`
- `adfox.yandex.ru`
- `bdapi-ads.realmemobile.com`
- `bdapi-in-ads.realmemobile.com`