### PR TITLE
stats.sh: process files in memory instead of on disk

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-echo \n "" > stats.out
+# clear file
+true > stats.out
 
 for TAG_DATE in $(git tag --sort=creatordate  --format='%(refname:short),%(creatordate:short)'); do
   # echo "$TAG_DATE"
   split=(${TAG_DATE//,/ })
   # echo ${split[0]}
-  git checkout tags/${split[0]} readmeData.json
-  entries=$(jq '.base.entries' readmeData.json)
+  entries=$(git show tags/${split[0]}:readmeData.json | jq '.base.entries')
+  if [[ -z "$entries" ]]; then continue; fi
   echo ${split[1]},${entries} >> stats.out
 done


### PR DESCRIPTION
Writing the file to the filesystem for all tags is unnecessary if the content can just be parsed in memory. This improves the performance:

Here the output of `time ./stats.sh`:

old
./stats.sh  5.96s user 26.53s system 94% cpu 34.533 total

new
./stats.sh  5.85s user 22.86s system 102% cpu 28.040 total

So a reduction of 6.5s (~20%) is achieved even on a computer with a decent SSD.