### PR TITLE
added domains from playstream.media

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -3046,3 +3046,9 @@
 
 # Added August 3, 2025
 0.0.0.0 trk.na.patagonia.com
+
+# Added August 8, 2025
+0.0.0.0 ads.playstream.media
+0.0.0.0 pscontent.playstream.media
+0.0.0.0 cdn.playstream.media
+0.0.0.0 prodcdn.playstream.media


### PR DESCRIPTION
Got some video ads and, upon inspecting my pi hole logs, I saw they were coming from playstream.media. Their website says they "built a connection between content creators marketeers and the audience" (emphasis on marketeers). So, I added all the domains and subdomains it pulled