### PR TITLE
Dockerfile: fix LegacyKeyValueFormat warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/python:3-alpine
 
-ENV IN_CONTAINER 1
+ENV IN_CONTAINER=1
 
 RUN apk add --no-cache git sudo
 
@@ -8,6 +8,6 @@ COPY . /hosts
 
 RUN pip install --no-cache-dir --upgrade -r /hosts/requirements.txt
 
-ENV PATH $PATH:/hosts
+ENV PATH=$PATH:/hosts
 
 WORKDIR /hosts


### PR DESCRIPTION
Should fix these:

```
Legacy key/value format with whitespace separator should not be used: Dockerfile#L3
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

Legacy key/value format with whitespace separator should not be used: Dockerfile#L11
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
```