### PR TITLE
stats.sh: speed up stats extraction

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -1,13 +1,69 @@
 #!/usr/bin/env bash
 
-# clear file
-true > stats.out
+# shellcheck enable=require-variable-braces
 
-for TAG_DATE in $(git tag --sort=creatordate  --format='%(refname:short),%(creatordate:short)'); do
-  # echo "$TAG_DATE"
-  split=(${TAG_DATE//,/ })
-  # echo ${split[0]}
-  entries=$(git show tags/${split[0]}:readmeData.json | jq '.base.entries')
-  if [[ -z "$entries" ]]; then continue; fi
-  echo ${split[1]},${entries} >> stats.out
+set -euo pipefail
+
+# Ensure required tools are installed
+for tool in git jq; do
+  if ! command -v "${tool}" > /dev/null 2>&1; then
+    echo "Error: ${tool} not found in PATH" >&2
+    exit 1
+  fi
+done
+
+# Clear output file
+: > stats.out
+
+# Collect "tag:readmeData.json date" pairs for all tags
+mapfile -t taglist < <(
+  git for-each-ref --sort=creatordate \
+    --format='%(refname:short) %(creatordate:short)' refs/tags |
+    awk '{print $1 ":readmeData.json " $2}'
+)
+
+# Feed all object names into one cat-file process
+exec 3< <(printf '%s\n' "${taglist[@]}" | cut -d' ' -f1 | git cat-file --batch)
+
+for line in "${taglist[@]}"; do
+  # Extract the date field by removing everything up to the first space
+  date=${line#* }
+
+  # Read one header line from fd 3
+  if ! read -r -a header_fields <&3; then
+    break
+  fi
+
+  # Skip if header is incomplete
+  if ((${#header_fields[@]} < 3)); then
+    continue
+  fi
+
+  size=${header_fields[2]}
+
+  # Validate that size is numeric
+  if [[ ! "${size}" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+
+  # Read exactly ${size} bytes of blob content
+  IFS= read -r -N "${size}" blob <&3
+
+  # Consume the newline that follows the blob
+  read -r _ <&3 || true
+
+  # Stream parse JSON only if blob is non-empty
+  if [[ -z "${blob}" ]]; then
+    continue
+  fi
+
+  # Stream parse JSON with jq in "raw input" mode to avoid subshell overhead
+  jq -nr --arg date "${date}" --argjson blob "${blob}" '
+    $blob.base.entries // empty
+    | if type=="array" then
+        .[] | "\($date),\(.)"
+      else
+        "\($date),\(.)"
+      end
+  ' >> stats.out 2> /dev/null || true
 done


### PR DESCRIPTION
@StevenBlack could you give this branch a go?

I tested it on Windows with MSYS and I see a 50-60% reduction in execution time. I also see more tags included that were previously skipped.

The code is a little cryptic but the idea is to stop spawning processes for each tag since there are hundreds of them.

```command
XhmikosR@DESKTOP-XXX MINGW32 /e/Downloads/hosts
$  time ./stats.sh
fatal: path 'readmeData.json' exists on disk, but not in 'tags/March-30-2012'

real    1m41.165s
user    0m14.286s
sys     0m17.729s

XhmikosR@DESKTOP-XXX MINGW32 /e/Downloads/hosts
$  git checkout . && git checkout patch-2
Updated 1 path from the index
Switched to branch 'patch-2'
Your branch is up to date with 'origin/patch-2'.

XhmikosR@DESKTOP-XXX MINGW32 /e/Downloads/hosts
$  time ./stats.sh

real    0m42.125s
user    0m8.529s
sys     0m7.787s
```

EDIT: I got it down to 25s (75% improvement) on my machine:

```command
XhmikosR@DESKTOP-XXX MINGW32 /e/Downloads/hosts
$  time ./stats.sh

real    0m25.498s
user    0m5.176s
sys     0m5.174s
```