### PR TITLE
Remove donmai.us

### DIFF
--- a/extensions/porn/sinfonietta/hosts
+++ b/extensions/porn/sinfonietta/hosts
@@ -12249,7 +12249,6 @@
 0.0.0.0 donfreeporn.com
 0.0.0.0 donkparty.com
 0.0.0.0 donlot.xyz
-0.0.0.0 donmai.us
 0.0.0.0 betabooru.donmai.us
 0.0.0.0 cdn.donmai.us
 0.0.0.0 danbooru.donmai.us


### PR DESCRIPTION
Is an innocent domain. default backend - 404

![Image](https://github.com/user-attachments/assets/e213d932-6721-42b5-b2f7-1f7413082d34)