### PR TITLE
Remove cdn.donmai.us

### DIFF
--- a/extensions/porn/clefspeare13/hosts
+++ b/extensions/porn/clefspeare13/hosts
@@ -2593,7 +2593,6 @@ fe80::1%lo0 localhost
 0.0.0.0 cdn.desiredbabes.com
 0.0.0.0 cdn.digitalbeautybabes.com
 0.0.0.0 cdn.dirtypornvids.com
-0.0.0.0 cdn.donmai.us
 0.0.0.0 cdn.doublepimpssl.com
 0.0.0.0 cdn.dtm.dmm.co.jp
 0.0.0.0 cdn.ebut.tv

--- a/extensions/porn/sinfonietta/hosts
+++ b/extensions/porn/sinfonietta/hosts
@@ -12251,7 +12251,6 @@
 0.0.0.0 donlot.xyz
 0.0.0.0 donmai.us
 0.0.0.0 betabooru.donmai.us
-0.0.0.0 cdn.donmai.us
 0.0.0.0 danbooru.donmai.us
 0.0.0.0 donnebellenude.com
 0.0.0.0 fr.donnebellenude.com


### PR DESCRIPTION
Blocking cdn.donmai.us affects safebooru.donmai.us The images won't show up.