### PR TITLE
Remove basecamp-shop.com.

### DIFF
--- a/hosts
+++ b/hosts
@@ -22303,7 +22303,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 bajkowewnetrzakids.pl
 0.0.0.0 banvar.com
 0.0.0.0 bartekzukiewicz.pl
-0.0.0.0 basecamp-shop.com
 0.0.0.0 bdjfehusi.shop
 0.0.0.0 bdsm.pl
 0.0.0.0 beauty-direct.pl
@@ -23648,7 +23647,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 www.bajkowewnetrzakids.pl
 0.0.0.0 www.banvar.com
 0.0.0.0 www.bartekzukiewicz.pl
-0.0.0.0 www.basecamp-shop.com
 0.0.0.0 www.bdjfehusi.shop
 0.0.0.0 www.bdsm.pl
 0.0.0.0 www.beauty-direct.pl


### PR DESCRIPTION
It is a Bulgarian outdoor equipment store- https://basecamp-shop.com.

I cannot image that it serves ads.