### PR TITLE
feat: Add isMalicious threat intelligence source

### DIFF
--- a/data/isMalicious/update.json
+++ b/data/isMalicious/update.json
@@ -1,0 +1,9 @@
+{
+  "name": "isMalicious",
+  "description": "Threat intelligence blocklist from [isMalicious.com](https://ismalicious.com) - aggregates malicious domains from multiple sources including phishing, malware, C2, and ransomware.",
+  "homeurl": "https://ismalicious.com/",
+  "frequency": "daily",
+  "issues": "https://github.com/hexablob/ismalicious.com/issues",
+  "url": "https://ismalicious.com/api/blocklist/download/blocklist-domains-all-hosts.txt",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Add [isMalicious.com](https://ismalicious.com) as a data source for malicious domain blocking.

## About isMalicious

isMalicious is a threat intelligence platform that aggregates data from multiple sources to identify malicious domains:

- **Phishing** - Sites impersonating legitimate services
- **Malware distribution** - Domains serving malicious software
- **Command & Control (C2)** - Botnet infrastructure
- **Ransomware** - Ransomware-related domains
- **Scam/Fraud** - Deceptive websites

## Blocklist Details

| Property | Value |
|----------|-------|
| **URL** | `https://ismalicious.com/api/blocklist/download/blocklist-domains-all-hosts.txt` |
| **Format** | Hosts file format (`0.0.0.0 domain`) |
| **Update Frequency** | Daily |
| **License** | MIT |

## Links

- Website: https://ismalicious.com
- Documentation: https://docs.ismalicious.com
- Blocklist Page: https://ismalicious.com/blocklist