### PR TITLE
Add SaneHosts to Third-Party Hosts Managers

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -599,6 +599,7 @@ devices under a variety of operating systems.
   most welcome.
 - [ViHoMa](https://github.com/cmabad/ViHoMa) is a Visual Hosts file Manager,
   written in Java, by Christian Martínez. Check it out!
+- [SaneHosts](https://sanehosts.com "SaneHosts") (for macOS): A native hosts file manager with profile-based blocking, Touch ID protection, and support for 200+ curated blocklists. Open source.
 
 ## Interesting Applications
 


### PR DESCRIPTION
## Summary

Adds [SaneHosts](https://sanehosts.com) to the **Third-Party Hosts Managers** section in the README.

SaneHosts is a native macOS hosts file manager that:
- **5 protection levels** (Essentials → Kitchen Sink) for instant setup
- **200+ curated blocklists** across 10 categories — ads, trackers, malware, privacy, social media, gambling, and more
- **Custom profiles** — build your own rules, import remote lists, combine and merge profiles
- **One-click activation** with automatic DNS cache flush
- **Open source**

The existing section lists a Windows tool and a Java tool — this adds the first macOS-native hosts manager to the list.

SaneHosts uses several of StevenBlack's unified hosts lists as blocklist sources in its catalog, so there's a natural connection to this project.