### PR TITLE
Rework "Generate unbound configuration files from blocklist files (#2833)"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,11 @@
               python3Packages.requests
             ];
           };
-        });
+        }
+      );
+
+      packages = forAllSystems (system: {
+        unbound = nixpkgsFor.${system}.callPackage ./unbound.nix { };
+      });
     };
 }

--- a/readme_template.md
+++ b/readme_template.md
@@ -386,8 +386,10 @@ To install hosts file on your machine add the following into your
 
 ### Nix Flake
 
-NixOS installations which are managed through _flakes_ can use the hosts file
-like this:
+NixOS installations which are managed through _flakes_ can directly use the `flake.nix` in this repository as an input.
+
+It contains a `nixosModule` that can be used to install the `hosts` file locally, as well as a package containing config files for the [Unbound](https://github.com/NLnetLabs/unbound) DNS server to be used as blocklists.
+
 
 ```nix
 {
@@ -403,7 +405,9 @@ like this:
     nixosConfigurations.my-hostname = {
       system = "<architecture>";
       modules = [
-        hosts.nixosModule {
+        # nixosModule to install hosts file locally:
+        hosts.nixosModule
+        {
           networking.stevenBlackHosts = {
             enable = true;
             # optionally:
@@ -413,6 +417,19 @@ like this:
             # blockPorn = true;
             # blockSocial = true;
           };
+        }
+
+        # configure unbound to use config as blocklist:
+        {
+          {
+            services.unbound = {
+              enable = true;
+              settings.server.include = [
+                "${hosts.packages.${system}.unbound}/hosts"
+                # alternates are also available, e.g. /fakenews, /fakenews-gambling etc.
+              ];
+            };
+          }
         }
       ];
     };

--- a/unbound.nix
+++ b/unbound.nix
@@ -1,13 +1,23 @@
 {
+  lib,
   runCommandLocal,
 }:
 let
   toUnboundConf = ''awk 'NF == 2 && $1 == "0.0.0.0" && $2 != "0.0.0.0" { printf "local-zone: \"%s\" always_nxdomain\n", $2 }'\'';
 in
-runCommandLocal "stevenblack-hosts-unbound" { src = ./.; } ''
-  mkdir $out
-  ${toUnboundConf} < $src/hosts > $out/hosts
-  for file in $src/alternates/*/hosts; do
-    ${toUnboundConf} < $file > $out/$(basename $(dirname $file))
-  done
-''
+runCommandLocal "stevenblack-hosts-unbound"
+  {
+    src = lib.sourceByRegex ./. [
+      "^hosts$"
+      "^alternates$"
+      "^alternates/[^/]+$"
+      "^alternates/[^/]+/hosts$"
+    ];
+  }
+  ''
+    mkdir $out
+    ${toUnboundConf} < $src/hosts > $out/hosts
+    for file in $src/alternates/*/hosts; do
+      ${toUnboundConf} < $file > $out/$(basename $(dirname $file))
+    done
+  ''

--- a/unbound.nix
+++ b/unbound.nix
@@ -1,0 +1,19 @@
+{
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  name = "stevenblack-hosts-unbound";
+  src = ./.;
+
+  installPhase =
+    let
+      toUnboundConf = ''awk 'NF == 2 && $1 == "0.0.0.0" && $2 != "0.0.0.0" { printf "local-zone: \"%s\" always_nxdomain\n", $2 }'\'';
+    in
+    ''
+      mkdir $out
+      cat $src/hosts | ${toUnboundConf} > $out/hosts
+      for file in alternates/*/hosts; do
+        cat $file | ${toUnboundConf} > $out/$(basename $(dirname $file))
+      done
+    '';
+}

--- a/unbound.nix
+++ b/unbound.nix
@@ -7,7 +7,7 @@ in
 runCommandLocal "stevenblack-hosts-unbound" { src = ./.; } ''
   mkdir $out
   ${toUnboundConf} < $src/hosts > $out/hosts
-  for file in alternates/*/hosts; do
+  for file in $src/alternates/*/hosts; do
     ${toUnboundConf} < $file > $out/$(basename $(dirname $file))
   done
 ''

--- a/unbound.nix
+++ b/unbound.nix
@@ -1,19 +1,13 @@
 {
-  stdenvNoCC,
+  runCommandLocal,
 }:
-stdenvNoCC.mkDerivation {
-  name = "stevenblack-hosts-unbound";
-  src = ./.;
-
-  installPhase =
-    let
-      toUnboundConf = ''awk 'NF == 2 && $1 == "0.0.0.0" && $2 != "0.0.0.0" { printf "local-zone: \"%s\" always_nxdomain\n", $2 }'\'';
-    in
-    ''
-      mkdir $out
-      cat $src/hosts | ${toUnboundConf} > $out/hosts
-      for file in alternates/*/hosts; do
-        cat $file | ${toUnboundConf} > $out/$(basename $(dirname $file))
-      done
-    '';
-}
+let
+  toUnboundConf = ''awk 'NF == 2 && $1 == "0.0.0.0" && $2 != "0.0.0.0" { printf "local-zone: \"%s\" always_nxdomain\n", $2 }'\'';
+in
+runCommandLocal "stevenblack-hosts-unbound" { src = ./.; } ''
+  mkdir $out
+  ${toUnboundConf} < $src/hosts > $out/hosts
+  for file in alternates/*/hosts; do
+    ${toUnboundConf} < $file > $out/$(basename $(dirname $file))
+  done
+''


### PR DESCRIPTION
Hi, I took the changes from #2833 and reworked them a bit.

Notably this:

- moves package definitions to a separate `packages.nix` file, making this repository useable by non flake users (as recommended by @toastal [here](https://github.com/StevenBlack/hosts/pull/2833#issuecomment-3832965693) (although I settled for `packages.nix` instead of `overlays.nix`))
- splits package defintions into `raw` and `unbound` sets, raw containing the original `hosts` files (this allows nix users to create derivations of the original files, adjusting them for other applications as required)
- uses a shorter `local-zone: "${domain}" refuse` unbound config notation (where applicable), shrinking unbound config size by ~50%

This depends on #3076 (it currently includes the changes from #3076 and I'll rebase once merged).

