### PR TITLE
Consolidate nix flake documentation in preparation for #3077

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -404,29 +404,21 @@ like this:
       system = "<architecture>";
       modules = [
         hosts.nixosModule {
-          networking.stevenBlackHosts.enable = true;
+          networking.stevenBlackHosts = {
+            enable = true;
+            # optionally:
+            # enableIPv6 = true;
+            # blockFakenews = true;
+            # blockGambling = true;
+            # blockPorn = true;
+            # blockSocial = true;
+          };
         }
       ];
     };
   };
 }
 ```
-
-The hosts extensions are also available with the following options:
-
-```nix
-{
-  networking.stevenBlackHosts = {
-    enableIPv6 = true;
-    blockFakenews = true;
-    blockGambling = true;
-    blockPorn = true;
-    blockSocial = true;
-  };
-}
-```
-
-IPv6 rules are enabled by default when `networking.enableIPv6` is set to `true`.
 
 ## Updating hosts file on Windows
 


### PR DESCRIPTION
I moved the nixos module options into the flake example, to consolidate the nix docs a bit, in preparation to add documentation on how to use the new unbound packages in #3077.

I dropped this line:
> IPv6 rules are enabled by default when `networking.enableIPv6` is set to `true`.

As it doesn't convey much information imo.