### PR TITLE
Add axios supply chain attack C2 domains

### DIFF
--- a/data/StevenBlack/hosts
+++ b/data/StevenBlack/hosts
@@ -3152,3 +3152,7 @@
 
 # Added March 29, 2026
 0.0.0.0 kra18.com
+
+# Added March 31, 2026
+0.0.0.0 sfrclak.com
+0.0.0.0 callnrwise.com


### PR DESCRIPTION
## Summary

Adds C2 domains used in the axios npm supply chain attack (March 31, 2026):

- `sfrclak.com` — primary C2 server (142.11.206.73)
- `callnrwise.com` — secondary C2 domain

Closes #3098

## Context

On March 31, 2026, an attacker compromised the npm account of the primary axios maintainer and published malicious versions (`axios@1.14.1`, `axios@0.30.4`) that inject a cross-platform RAT via the `plain-crypto-js@4.2.1` dependency. The RAT beacons to these domains every 60 seconds.

- **Advisory**: [GHSA-fw8c-xr5c-95f9](https://github.com/advisories/GHSA-fw8c-xr5c-95f9)
- **Analysis**: [Socket.dev writeup](https://socket.dev/blog/axios-npm-package-compromised), [StepSecurity writeup](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan)
- **Scope**: ~83M weekly downloads affected during the ~3 hour window the malicious versions were live