### PR TITLE
Doc: Add docker build instructions without git clone

### DIFF
--- a/readme_template.md
+++ b/readme_template.md
@@ -131,6 +131,12 @@ Build the Docker container from the root of this repo like this:
 docker build --no-cache . -t stevenblack-hosts
 ```
 
+Or without cloning (directly from GitHub):
+
+```sh
+docker build --no-cache https://github.com/StevenBlack/hosts.git -t stevenblack-hosts
+```
+
 Then run your command as such:
 
 ```sh


### PR DESCRIPTION
Add instructions for building Docker image directly from GitHub.

With modern enough Docker, this just works:

```
$ docker build --no-cache https://github.com/StevenBlack/hosts.git -t stevenblack-hosts
[+] Building 70.7s (8/8) FINISHED                                                                                                                      
 => [internal] load git source https://github.com/StevenBlack/hosts.git                                                                           4.2s
 => [internal] load metadata for docker.io/library/python:3-alpine                                                                                5.7s
 => [1/5] FROM docker.io/library/python:3-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a                          5.5s 
 => => resolve docker.io/library/python:3-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a                          0.1s 
 => => sha256:9e03a80a1cc6bec92c07e5eb616b295ec3c1660faa90fd08a4a4ca92e03fafde 1.74kB / 1.74kB                                                    0.0s 
 => => sha256:1136aa64d9c50e7684573f089718ac9919575f9d39ea413410a0614552d006e5 4.71kB / 4.71kB                                                    0.0s 
 => => sha256:d17f077ada118cc762df373ff803592abf2dfa3ddafaa7381e364dd27a88fca7 4.20MB / 4.20MB                                                    1.9s
 => => sha256:ce044e508c31b550012103ac403762a3f10a13a30aa1a69e117060b0d6d43a9d 457.91kB / 457.91kB                                                0.6s
 => => sha256:9def3ce2dae125b2efcb5100bde3ecee4d9b5f78b9088098753338af9e277661 13.48MB / 13.48MB                                                  3.5s
 => => sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a 10.29kB / 10.29kB                                                  0.0s
 => => sha256:9363636621cd74af602f2571bc4ee6ffe761c3ddcdbb85e4e29d3044e1d555e6 250B / 250B                                                        1.0s
 => => extracting sha256:d17f077ada118cc762df373ff803592abf2dfa3ddafaa7381e364dd27a88fca7                                                         0.2s
 => => extracting sha256:ce044e508c31b550012103ac403762a3f10a13a30aa1a69e117060b0d6d43a9d                                                         0.1s
 => => extracting sha256:9def3ce2dae125b2efcb5100bde3ecee4d9b5f78b9088098753338af9e277661                                                         0.8s
 => => extracting sha256:9363636621cd74af602f2571bc4ee6ffe761c3ddcdbb85e4e29d3044e1d555e6                                                         0.0s
 => [2/5] RUN apk add --no-cache git sudo                                                                                                        28.3s
 => [3/5] COPY . /hosts                                                                                                                          17.2s
 => [4/5] RUN pip install --no-cache-dir --upgrade -r /hosts/requirements.txt                                                                     7.9s 
 => [5/5] WORKDIR /hosts                                                                                                                          0.9s 
 => exporting to image                                                                                                                            0.8s 
 => => exporting layers                                                                                                                           0.7s 
 => => writing image sha256:ee90f188f29247208d3eff1f455a2f1d7b27de292fa74850427b115b38105c9d                                                      0.1s 
 => => naming to docker.io/library/stevenblack-hosts                                                                                              0.0s 
```