### PR TITLE
removed macos host lines

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,19 @@
                 orig = builtins.readFile (
                   "${self}/" + (lib.optionalString (alternatesList != [ ]) alternatesPath) + "hosts"
                 );
-                ipv6 = builtins.replaceStrings [ "0.0.0.0" ] [ "::" ] orig;
+                filterHosts = text:
+                  builtins.concatStringsSep "\n"
+                    (builtins.filter
+                      (line:
+                        let first = builtins.elemAt (lib.splitString " " line) 0;
+                        in !(lib.hasInfix "%" first)
+                      )
+                      (lib.splitString "\n" text)
+                    );
+                filtered = filterHosts orig;
+                ipv6 = builtins.replaceStrings [ "0.0.0.0" ] [ "::" ] filtered;
               in
-              lib.mkAfter (orig + (lib.optionalString cfg.enableIPv6 ("\n" + ipv6)));
+              lib.mkAfter (filtered + (lib.optionalString cfg.enableIPv6 ("\n" + ipv6)));
           };
         };
 


### PR DESCRIPTION
This is for NixOS and therefore uneeded and causes issues with dnsmasq.

This is a simple modification that removes these OSX specific lines from the host files.

This is required on NixOS as it is immutable, therefore the file needs to be modified in place before it can be installed.

I've checked the file and there seems to no extra collateral damage. All comments start with # and therefore cannot contain `%`, and even if they did it's a harmless removal.

The rest of the lines are actual host file information which we want to autoremove since it's incompatible with NixOS.